### PR TITLE
Build a playable six-operator tactical command prototype

### DIFF
--- a/.github/workflows/tactical-prototype-static.yml
+++ b/.github/workflows/tactical-prototype-static.yml
@@ -1,0 +1,25 @@
+name: Tactical prototype static checks
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validate tactical prototype structure
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+
+      - name: Run structural validator
+        run: python3 tools/validate_tactical_prototype.py

--- a/Assets/Scenes/TacticalSquadPrototype.unity
+++ b/Assets/Scenes/TacticalSquadPrototype.unity
@@ -1,0 +1,154 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 9
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_IndirectSpecularColor: {r: 0, g: 0, b: 0, a: 1}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 12
+  m_GIWorkflowMode: 1
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 0
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 1
+    m_PVRFilterTypeAO: 1
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 0}
+  m_LightingSettings: {fileID: 0}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 2
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    accuratePlacement: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &1000
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1001}
+  m_Layer: 0
+  m_Name: Runtime-generated prototype. Press Play.
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1001
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1000}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/Scenes/TacticalSquadPrototype.unity.meta
+++ b/Assets/Scenes/TacticalSquadPrototype.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 30d36ee0d7234e81a6365d7640aa5e8f
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/TacticalSquad.meta
+++ b/Assets/Scripts/TacticalSquad.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fbd63ef1b1d147cab74ff0c1bc5a00b2
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/TacticalSquad/Editor.meta
+++ b/Assets/Scripts/TacticalSquad/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b8381a3ad9c14ef7b95f621cc4c81f65
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/TacticalSquad/Editor/Sipoga.Tactics.Editor.asmdef
+++ b/Assets/Scripts/TacticalSquad/Editor/Sipoga.Tactics.Editor.asmdef
@@ -1,0 +1,16 @@
+{
+  "name": "Sipoga.Tactics.Editor",
+  "references": [
+    "Sipoga.Tactics"
+  ],
+  "optionalUnityReferences": [],
+  "includePlatforms": [
+    "Editor"
+  ],
+  "excludePlatforms": [],
+  "allowUnsafeCode": false,
+  "overrideReferences": false,
+  "precompiledReferences": [],
+  "autoReferenced": true,
+  "defineConstraints": []
+}

--- a/Assets/Scripts/TacticalSquad/Editor/Sipoga.Tactics.Editor.asmdef.meta
+++ b/Assets/Scripts/TacticalSquad/Editor/Sipoga.Tactics.Editor.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a60190e439a245efae2288c7ec56bbbd
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/TacticalSquad/Editor/TacticalPrototypeSceneBuilder.cs
+++ b/Assets/Scripts/TacticalSquad/Editor/TacticalPrototypeSceneBuilder.cs
@@ -1,0 +1,74 @@
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEditor.SceneManagement;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+namespace Sipoga.Tactics.Editor
+{
+    public static class TacticalPrototypeSceneBuilder
+    {
+        private const string ScenePath = "Assets/Scenes/TacticalSquadPrototype.unity";
+
+        [MenuItem("Sipoga/Tactical Prototype/Open Glasshouse")]
+        public static void OpenPrototype()
+        {
+            if (!EditorSceneManager.SaveCurrentModifiedScenesIfUserWantsTo())
+            {
+                return;
+            }
+
+            EditorSceneManager.OpenScene(ScenePath, OpenSceneMode.Single);
+            EnsureInBuildSettings();
+        }
+
+        [MenuItem("Sipoga/Tactical Prototype/Run Glasshouse")]
+        public static void RunPrototype()
+        {
+            OpenPrototype();
+            if (SceneManager.GetActiveScene().path == ScenePath)
+            {
+                EditorApplication.isPlaying = true;
+            }
+        }
+
+        [MenuItem("Sipoga/Tactical Prototype/Rebuild Empty Launch Scene")]
+        public static void RebuildPrototypeScene()
+        {
+            if (!EditorSceneManager.SaveCurrentModifiedScenesIfUserWantsTo())
+            {
+                return;
+            }
+
+            Scene scene = EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Single);
+            GameObject marker = new GameObject("Runtime-generated prototype. Press Play.");
+            marker.transform.position = Vector3.zero;
+            EditorSceneManager.SaveScene(scene, ScenePath);
+            EnsureInBuildSettings();
+            Selection.activeGameObject = marker;
+            AssetDatabase.Refresh();
+        }
+
+        private static void EnsureInBuildSettings()
+        {
+            List<EditorBuildSettingsScene> scenes =
+                new List<EditorBuildSettingsScene>(EditorBuildSettings.scenes);
+            for (int i = 0; i < scenes.Count; i++)
+            {
+                if (scenes[i].path == ScenePath)
+                {
+                    if (!scenes[i].enabled)
+                    {
+                        scenes[i] = new EditorBuildSettingsScene(ScenePath, true);
+                        EditorBuildSettings.scenes = scenes.ToArray();
+                    }
+
+                    return;
+                }
+            }
+
+            scenes.Add(new EditorBuildSettingsScene(ScenePath, true));
+            EditorBuildSettings.scenes = scenes.ToArray();
+        }
+    }
+}

--- a/Assets/Scripts/TacticalSquad/Editor/TacticalPrototypeSceneBuilder.cs.meta
+++ b/Assets/Scripts/TacticalSquad/Editor/TacticalPrototypeSceneBuilder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 95e22196d952448e9f8bebaa9ea625be
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/TacticalSquad/GlasshouseScenario.cs
+++ b/Assets/Scripts/TacticalSquad/GlasshouseScenario.cs
@@ -1,0 +1,381 @@
+using UnityEngine;
+
+namespace Sipoga.Tactics
+{
+    /// <summary>
+    /// A deliberately original tactical slice built to teach the same kind of
+    /// interlocking map-control logic that makes professional destruction shooters
+    /// interesting. It does not reproduce any commercial map, room sequence, names,
+    /// dimensions, art, or assets.
+    /// </summary>
+    public static class GlasshouseScenario
+    {
+        public const string ScenarioId = "glasshouse";
+        public const string FlexUnitId = "foxtrot";
+        public const string PermeableScreenId = "overwatch_screen";
+
+        public const string CrimsonRouteId = "crimson_route";
+        public const string ServiceRouteId = "service_route";
+        public const string ColdHatchRouteId = "cold_hatch_route";
+
+        public static TacticalScenarioDefinition Create()
+        {
+            TacticalScenarioDefinition scenario = new TacticalScenarioDefinition(
+                ScenarioId,
+                "GLASSHOUSE",
+                "prototype-0.1",
+                "Six operators maintain a network of promises across two floors. " +
+                "The reserve operator repairs whichever dependency fails first.");
+
+            AddPositions(scenario);
+            AddRoutes(scenario);
+            AddSurfaces(scenario);
+            AddUnits(scenario);
+            AddCoverageRules(scenario);
+            AddFlexOptions(scenario);
+            AddAttackPlaybooks(scenario);
+            return scenario;
+        }
+
+        private static void AddPositions(TacticalScenarioDefinition scenario)
+        {
+            // Ground floor.
+            scenario.Positions.Add(Position("alpha_archive", "Archive anchor", -4.8f, 1.0f, -2.5f, 0));
+            scenario.Positions.Add(Position("alpha_fallback", "Archive deep cover", -7.0f, 1.0f, -4.7f, 0));
+            scenario.Positions.Add(Position("alpha_execute", "Archive threshold", -2.7f, 1.0f, -1.8f, 0));
+
+            scenario.Positions.Add(Position("delta_packing", "Packing hinge", 2.7f, 1.0f, -1.5f, 0));
+            scenario.Positions.Add(Position("delta_fallback", "Packing interior", 0.8f, 1.0f, -3.8f, 0));
+            scenario.Positions.Add(Position("delta_execute", "Packing threshold", 1.4f, 1.0f, -1.3f, 0));
+
+            scenario.Positions.Add(Position("echo_crimson", "Crimson delay", 6.3f, 1.0f, 2.8f, 0));
+            scenario.Positions.Add(Position("echo_fallback", "Crimson fallback", 4.3f, 1.0f, 0.7f, 0));
+            scenario.Positions.Add(Position("echo_execute", "Packing east", 3.7f, 1.0f, -0.2f, 0));
+
+            scenario.Positions.Add(Position("foxtrot_reserve", "Central reserve", 0.0f, 1.0f, 2.1f, 0));
+            scenario.Positions.Add(Position("foxtrot_fallback", "Reserve fallback", -1.5f, 1.0f, -1.1f, 0));
+            scenario.Positions.Add(Position("foxtrot_execute", "Central execute", 0.0f, 1.0f, -0.8f, 0));
+            scenario.Positions.Add(Position("flex_crimson", "Crimson backup", 4.7f, 1.0f, 1.5f, 0));
+            scenario.Positions.Add(Position("flex_service", "Service backup", -0.8f, 1.0f, 0.3f, 0));
+            scenario.Positions.Add(Position("flex_cold", "Cold Store backup", -3.3f, 1.0f, 2.8f, 0));
+
+            // Upper floor catwalks.
+            scenario.Positions.Add(Position("bravo_overwatch", "Overwatch screen", -4.8f, 4.35f, 1.2f, 1));
+            scenario.Positions.Add(Position("bravo_fallback", "Overwatch rear", -7.0f, 4.35f, -0.7f, 1));
+            scenario.Positions.Add(Position("bravo_execute", "Overwatch bridge", -2.7f, 4.35f, -1.8f, 1));
+
+            scenario.Positions.Add(Position("charlie_gallery", "Gallery crossfire", 4.5f, 4.35f, -1.8f, 1));
+            scenario.Positions.Add(Position("charlie_fallback", "Gallery back rail", 2.2f, 4.35f, -3.7f, 1));
+            scenario.Positions.Add(Position("charlie_execute", "Gallery bridge", 3.4f, 4.35f, -0.4f, 1));
+        }
+
+        private static void AddRoutes(TacticalScenarioDefinition scenario)
+        {
+            scenario.Routes.Add(new TacticalRouteDefinition(
+                CrimsonRouteId,
+                "CRIMSON STAIR",
+                "A deep stair route that should enter three overlapping lines of control.",
+                3,
+                new Vector3(8.2f, 0.13f, 6.8f),
+                new Vector3(3.0f, 0.13f, 0.3f)));
+
+            scenario.Routes.Add(new TacticalRouteDefinition(
+                ServiceRouteId,
+                "SERVICE HALL",
+                "The direct objective route. Two operators must keep it from becoming a clean sprint.",
+                2,
+                new Vector3(-0.3f, 0.14f, 7.7f),
+                new Vector3(-0.3f, 0.14f, -1.2f)));
+
+            scenario.Routes.Add(new TacticalRouteDefinition(
+                ColdHatchRouteId,
+                "COLD HATCH",
+                "A vertical opening remotely denied from Overwatch through a permeable screen.",
+                1,
+                new Vector3(-5.2f, 0.15f, 6.5f),
+                new Vector3(-5.2f, 0.15f, 1.4f)));
+        }
+
+        private static void AddSurfaces(TacticalScenarioDefinition scenario)
+        {
+            scenario.Surfaces.Add(new TacticalSurfaceDefinition(
+                PermeableScreenId,
+                "Overwatch permeable screen",
+                TacticalSurfaceState.Permeable,
+                new Vector3(-3.8f, 4.4f, 1.2f),
+                new Vector3(0.22f, 2.35f, 3.8f)));
+        }
+
+        private static void AddUnits(TacticalScenarioDefinition scenario)
+        {
+            scenario.Units.Add(new TacticalUnitPlan(
+                "alpha",
+                "ALPHA",
+                "Service anchor",
+                TacticalResponsibilityKind.DenyRoute,
+                "alpha_archive",
+                "alpha_fallback",
+                "alpha_execute",
+                false,
+                new Color(0.30f, 0.78f, 1.00f),
+                "Deny the Service Hall execute from Archive.",
+                "Delta links Packing to Service, while Bravo protects the vertical opening behind you.",
+                "Packing is lost, or the attack splits Service from the upper-floor support network.",
+                "Fall back to Archive deep cover without abandoning the objective threshold."));
+
+            scenario.Units.Add(new TacticalUnitPlan(
+                "bravo",
+                "BRAVO",
+                "Remote hatch denial",
+                TacticalResponsibilityKind.DenySurface,
+                "bravo_overwatch",
+                "bravo_fallback",
+                "bravo_execute",
+                false,
+                new Color(0.50f, 0.92f, 0.62f),
+                "Deny the Cold Hatch from Overwatch through the permeable screen.",
+                "Alpha owns the floor below, and the screen permits a remote line of fire without exposing the objective room.",
+                "The screen is sealed, Overwatch is isolated, or you leave the exact line that reaches the hatch.",
+                "Fall back to the Overwatch rear rail, then re-establish control from a safer depth."));
+
+            scenario.Units.Add(new TacticalUnitPlan(
+                "charlie",
+                "CHARLIE",
+                "Gallery crossfire",
+                TacticalResponsibilityKind.Crossfire,
+                "charlie_gallery",
+                "charlie_fallback",
+                "charlie_execute",
+                false,
+                new Color(1.00f, 0.66f, 0.28f),
+                "Hold Gallery's long crossfire on Crimson Stair.",
+                "Delta and Echo watch the same route from different depths, so an attacker cannot clear every angle at once.",
+                "Gallery is isolated, or Delta leaves the Packing hinge and removes the middle layer of the crossfire.",
+                "Fall back to the Gallery back rail before the attack can convert pressure into a pinch."));
+
+            scenario.Units.Add(new TacticalUnitPlan(
+                "delta",
+                "DELTA",
+                "Two-route hinge",
+                TacticalResponsibilityKind.HoldAngle,
+                "delta_packing",
+                "delta_fallback",
+                "delta_execute",
+                false,
+                new Color(0.78f, 0.55f, 1.00f),
+                "Link both Crimson Stair and Service Hall from the Packing hinge.",
+                "Charlie and Echo complete the stair crossfire, while Alpha completes Service coverage.",
+                "This is a hinge position: losing it weakens two routes at the same time.",
+                "Fall back to Packing interior and force the reserve operator to choose which promise matters more."));
+
+            scenario.Units.Add(new TacticalUnitPlan(
+                "echo",
+                "ECHO",
+                "Stair delay",
+                TacticalResponsibilityKind.Delay,
+                "echo_crimson",
+                "echo_fallback",
+                "echo_execute",
+                false,
+                new Color(1.00f, 0.40f, 0.48f),
+                "Delay the Crimson Stair entry, then leave before the route becomes a close-range trap.",
+                "Charlie and Delta punish anyone who chases through your retreat path.",
+                "Gallery is isolated, Packing turns away, or you remain after the supporting angles disappear.",
+                "Fall back to the Packing threshold and preserve the final layer of the stair defense."));
+
+            scenario.Units.Add(new TacticalUnitPlan(
+                FlexUnitId,
+                "FOXTROT",
+                "Reserve",
+                TacticalResponsibilityKind.Reserve,
+                "foxtrot_reserve",
+                "foxtrot_fallback",
+                "foxtrot_execute",
+                true,
+                new Color(0.98f, 0.90f, 0.28f),
+                "Remain in reserve and replace the first broken promise.",
+                "A central starting position keeps every backup route reachable.",
+                "Two simultaneous failures can exceed one reserve operator's capacity.",
+                "Return to central reserve whenever all baseline responsibilities are restored."));
+        }
+
+        private static void AddCoverageRules(TacticalScenarioDefinition scenario)
+        {
+            scenario.CoverageRules.Add(new TacticalCoverageRule(
+                "alpha_service",
+                "alpha",
+                ServiceRouteId,
+                "alpha_archive",
+                "Alpha controls the objective end of Service Hall."));
+
+            scenario.CoverageRules.Add(new TacticalCoverageRule(
+                "bravo_cold_hatch",
+                "bravo",
+                ColdHatchRouteId,
+                "bravo_overwatch",
+                PermeableScreenId,
+                new[] { TacticalSurfaceState.Permeable, TacticalSurfaceState.Open },
+                "Bravo's remote denial only exists while the Overwatch screen transmits fire."));
+
+            scenario.CoverageRules.Add(new TacticalCoverageRule(
+                "charlie_crimson",
+                "charlie",
+                CrimsonRouteId,
+                "charlie_gallery",
+                "Charlie supplies the upper Gallery layer of the Crimson crossfire."));
+
+            scenario.CoverageRules.Add(new TacticalCoverageRule(
+                "delta_crimson",
+                "delta",
+                CrimsonRouteId,
+                "delta_packing",
+                "Delta supplies the middle layer of the Crimson crossfire."));
+
+            scenario.CoverageRules.Add(new TacticalCoverageRule(
+                "delta_service",
+                "delta",
+                ServiceRouteId,
+                "delta_packing",
+                "Delta links Packing to Service Hall."));
+
+            scenario.CoverageRules.Add(new TacticalCoverageRule(
+                "echo_crimson",
+                "echo",
+                CrimsonRouteId,
+                "echo_crimson",
+                "Echo supplies the forward delay layer of the Crimson crossfire."));
+        }
+
+        private static void AddFlexOptions(TacticalScenarioDefinition scenario)
+        {
+            scenario.FlexOptions.Add(new TacticalFlexOption(
+                CrimsonRouteId,
+                "flex_crimson",
+                "Repair Crimson Stair",
+                3,
+                "The reserve replaces one missing stair angle from the Crimson backup position."));
+
+            scenario.FlexOptions.Add(new TacticalFlexOption(
+                ServiceRouteId,
+                "flex_service",
+                "Repair Service Hall",
+                2,
+                "The reserve restores a second Service line from the central threshold."));
+
+            scenario.FlexOptions.Add(new TacticalFlexOption(
+                ColdHatchRouteId,
+                "flex_cold",
+                "Repair Cold Hatch",
+                1,
+                "The reserve moves below the hatch and replaces the lost remote denial with direct control."));
+        }
+
+        private static void AddAttackPlaybooks(TacticalScenarioDefinition scenario)
+        {
+            TacticalAttackPlaybook isolateGallery = new TacticalAttackPlaybook(
+                "isolate_gallery",
+                "ISOLATE GALLERY",
+                "The attack ignores the objective, removes the operator making Crimson safe, then accelerates through the gap.",
+                "The visible duel is not the real target. The attack is deleting a supporting promise before entering.",
+                20.0f);
+            isolateGallery.Steps.Add(TacticalAttackStep.Log(
+                0.6f,
+                "Attackers drone Gallery and deliberately ignore the objective door."));
+            isolateGallery.Steps.Add(TacticalAttackStep.Pressure(
+                2.0f,
+                CrimsonRouteId,
+                4,
+                "Four attackers begin pressuring Crimson Stair."));
+            isolateGallery.Steps.Add(TacticalAttackStep.UnitDown(
+                5.0f,
+                "charlie",
+                true,
+                "Gallery is isolated. Charlie goes down and the three-angle stair crossfire loses its upper layer."));
+            isolateGallery.Steps.Add(TacticalAttackStep.Pressure(
+                10.0f,
+                CrimsonRouteId,
+                7,
+                "The attack accelerates through Crimson before the defense can live with the new geometry."));
+            isolateGallery.Steps.Add(TacticalAttackStep.Log(
+                16.0f,
+                "Foxtrot must physically reach Crimson backup before the route is truly repaired."));
+            scenario.AttackPlaybooks.Add(isolateGallery);
+
+            TacticalAttackPlaybook blockRemote = new TacticalAttackPlaybook(
+                "block_remote_control",
+                "BLOCK REMOTE CONTROL",
+                "The attack changes one surface state, deleting a line of control without fighting the operator who owned it.",
+                "Map destruction is not decoration. A surface state can switch an entire responsibility on or off.",
+                19.0f);
+            blockRemote.Steps.Add(TacticalAttackStep.Log(
+                0.6f,
+                "Attackers identify that Cold Hatch is denied remotely from Overwatch."));
+            blockRemote.Steps.Add(TacticalAttackStep.Pressure(
+                2.0f,
+                ColdHatchRouteId,
+                4,
+                "Cold Hatch pressure begins while Bravo still owns the remote line."));
+            blockRemote.Steps.Add(TacticalAttackStep.Surface(
+                5.0f,
+                PermeableScreenId,
+                TacticalSurfaceState.Sealed,
+                "The Overwatch screen is sealed. Bravo remains alive, but the remote promise disappears."));
+            blockRemote.Steps.Add(TacticalAttackStep.Pressure(
+                9.0f,
+                ColdHatchRouteId,
+                7,
+                "The attack commits to Cold Hatch after removing its supporting geometry."));
+            blockRemote.Steps.Add(TacticalAttackStep.Log(
+                15.0f,
+                "Foxtrot repairs the route by taking direct control below the hatch."));
+            scenario.AttackPlaybooks.Add(blockRemote);
+
+            TacticalAttackPlaybook wideSplit = new TacticalAttackPlaybook(
+                "wide_split",
+                "WIDE SPLIT",
+                "The attack removes the single hinge that supports two routes, forcing one reserve operator to choose.",
+                "A reserve can repair one failure. Creating two failures at once turns map control into a prioritization problem.",
+                22.0f);
+            wideSplit.Steps.Add(TacticalAttackStep.Pressure(
+                1.0f,
+                ServiceRouteId,
+                4,
+                "Two attackers show presence in Service Hall."));
+            wideSplit.Steps.Add(TacticalAttackStep.Pressure(
+                2.0f,
+                CrimsonRouteId,
+                6,
+                "A heavier group takes space toward Crimson Stair."));
+            wideSplit.Steps.Add(TacticalAttackStep.UnitDown(
+                5.0f,
+                "delta",
+                true,
+                "Delta goes down. One casualty weakens both Crimson and Service at the same instant."));
+            wideSplit.Steps.Add(TacticalAttackStep.Pressure(
+                11.0f,
+                CrimsonRouteId,
+                1,
+                "The Crimson group stops advancing and holds the defense in place."));
+            wideSplit.Steps.Add(TacticalAttackStep.Pressure(
+                11.2f,
+                ServiceRouteId,
+                8,
+                "The real execute rotates into Service, forcing Foxtrot to abandon the first repair."));
+            wideSplit.Steps.Add(TacticalAttackStep.Log(
+                18.0f,
+                "The route with the greater immediate pressure wins the reserve operator."));
+            scenario.AttackPlaybooks.Add(wideSplit);
+        }
+
+        private static TacticalPositionDefinition Position(
+            string id,
+            string label,
+            float x,
+            float y,
+            float z,
+            int floor)
+        {
+            return new TacticalPositionDefinition(id, label, new Vector3(x, y, z), floor);
+        }
+    }
+}

--- a/Assets/Scripts/TacticalSquad/GlasshouseScenario.cs.meta
+++ b/Assets/Scripts/TacticalSquad/GlasshouseScenario.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ebb328d7b59540eab0b212dfc5d8206e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/TacticalSquad/Sipoga.Tactics.asmdef
+++ b/Assets/Scripts/TacticalSquad/Sipoga.Tactics.asmdef
@@ -1,0 +1,12 @@
+{
+  "name": "Sipoga.Tactics",
+  "references": [],
+  "optionalUnityReferences": [],
+  "includePlatforms": [],
+  "excludePlatforms": [],
+  "allowUnsafeCode": false,
+  "overrideReferences": false,
+  "precompiledReferences": [],
+  "autoReferenced": true,
+  "defineConstraints": []
+}

--- a/Assets/Scripts/TacticalSquad/Sipoga.Tactics.asmdef.meta
+++ b/Assets/Scripts/TacticalSquad/Sipoga.Tactics.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 8417531358cb4640b2087c7d5670181a
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/TacticalSquad/TacticalCommandHud.cs
+++ b/Assets/Scripts/TacticalSquad/TacticalCommandHud.cs
@@ -1,0 +1,305 @@
+using UnityEngine;
+
+namespace Sipoga.Tactics
+{
+    /// <summary>
+    /// A compact command layer over the explanatory HUD. Guided mode demonstrates
+    /// the plan automatically; Command mode turns the same scenario into a reaction
+    /// game where the player must send the reserve to the right broken promise.
+    /// </summary>
+    public sealed class TacticalCommandHud : MonoBehaviour
+    {
+        private const float DesignWidth = 1600f;
+        private const float DesignHeight = 900f;
+
+        private TacticalSquadDirector _director;
+        private GUIStyle _bar;
+        private GUIStyle _button;
+        private GUIStyle _strongButton;
+        private GUIStyle _label;
+        private GUIStyle _muted;
+        private GUIStyle _prompt;
+        private GUIStyle _reportPanel;
+        private GUIStyle _grade;
+        private GUIStyle _reportTitle;
+        private GUIStyle _reportBody;
+        private bool _stylesReady;
+
+        public void Initialize(TacticalSquadDirector director)
+        {
+            _director = director;
+        }
+
+        private void OnGUI()
+        {
+            if (_director == null || _director.Evaluation == null)
+            {
+                return;
+            }
+
+            GUI.depth = -20;
+            EnsureStyles();
+            float scale = Mathf.Min(Screen.width / DesignWidth, Screen.height / DesignHeight);
+            if (scale <= 0f)
+            {
+                return;
+            }
+
+            Matrix4x4 previousMatrix = GUI.matrix;
+            GUI.matrix = Matrix4x4.TRS(
+                Vector3.zero,
+                Quaternion.identity,
+                new Vector3(scale, scale, 1f));
+
+            DrawDecisionPrompt();
+            DrawCommandBar();
+            DrawAfterActionReport();
+
+            GUI.matrix = previousMatrix;
+            GUI.enabled = true;
+            GUI.backgroundColor = Color.white;
+            GUI.contentColor = Color.white;
+        }
+
+        private void DrawCommandBar()
+        {
+            GUI.Box(new Rect(386f, 844f, 784f, 40f), GUIContent.none, _bar);
+
+            string modeLabel = _director.ControlMode == TacticalControlMode.Guided
+                ? "GUIDED [M]"
+                : "COMMAND [M]";
+            if (GUI.Button(new Rect(394f, 850f, 110f, 28f), modeLabel, _strongButton))
+            {
+                _director.ToggleControlMode();
+            }
+
+            bool commandMode = _director.ControlMode == TacticalControlMode.Command;
+            GUI.enabled = commandMode;
+            TacticalFlexDirective directive = _director.Evaluation.FlexDirective;
+            bool hasRecommendation = directive != null && directive.IsActive;
+
+            GUI.enabled = commandMode && hasRecommendation;
+            if (GUI.Button(new Rect(510f, 850f, 150f, 28f), "SEND BEST [Q]", _button))
+            {
+                _director.OrderFlexToRecommended();
+            }
+
+            GUI.enabled = commandMode;
+            for (int i = 0; i < _director.Scenario.Routes.Count; i++)
+            {
+                TacticalRouteDefinition route = _director.Scenario.Routes[i];
+                TacticalRouteRuntimeState routeState = _director.Evaluation.GetRoute(route.Id);
+                bool recommended = hasRecommendation && directive.RouteId == route.Id;
+                Color oldBackground = GUI.backgroundColor;
+                if (recommended)
+                {
+                    GUI.backgroundColor = new Color(1.00f, 0.63f, 0.20f);
+                }
+                else if (routeState != null && routeState.IsSecured)
+                {
+                    GUI.backgroundColor = new Color(0.35f, 0.52f, 0.48f);
+                }
+                else
+                {
+                    GUI.backgroundColor = new Color(0.86f, 0.30f, 0.32f);
+                }
+
+                float x = 666f + i * 104f;
+                if (GUI.Button(
+                    new Rect(x, 850f, 98f, 28f),
+                    "F > " + ShortRouteName(route.Id),
+                    _button))
+                {
+                    _director.OrderFlexToRoute(route.Id);
+                }
+
+                GUI.backgroundColor = oldBackground;
+            }
+
+            GUI.enabled = true;
+            TacticalMissionReport report = _director.MissionReport;
+            string score = report != null
+                ? "CONTROL  " + report.ControlPercent.ToString("0") + "%"
+                : "CONTROL  --";
+            GUI.Label(new Rect(982f, 851f, 174f, 26f), score, _label);
+        }
+
+        private void DrawDecisionPrompt()
+        {
+            if (_director.Phase != TacticalPrototypePhase.Execution)
+            {
+                return;
+            }
+
+            TacticalFlexDirective directive = _director.Evaluation.FlexDirective;
+            if (directive == null || !directive.IsActive)
+            {
+                return;
+            }
+
+            TacticalRouteDefinition route = _director.Engine.GetRouteDefinition(directive.RouteId);
+            TacticalRouteRuntimeState routeState = _director.Evaluation.GetRoute(directive.RouteId);
+            if (route == null || routeState == null || routeState.IsFlexHolding)
+            {
+                return;
+            }
+
+            string prefix = _director.ControlMode == TacticalControlMode.Guided
+                ? "GUIDED RESPONSE"
+                : "YOUR DECISION";
+            string text =
+                prefix + "  //  " + route.Label + " IS " + routeState.StatusLabel +
+                "  //  SEND FOXTROT TO " + directive.ResponsibilityLabel.ToUpperInvariant();
+            GUI.Box(new Rect(444f, 190f, 712f, 52f), text, _prompt);
+        }
+
+        private void DrawAfterActionReport()
+        {
+            if (_director.Phase != TacticalPrototypePhase.AfterAction)
+            {
+                return;
+            }
+
+            TacticalMissionReport report = _director.MissionReport;
+            if (report == null)
+            {
+                return;
+            }
+
+            Rect panel = new Rect(452f, 190f, 696f, 270f);
+            GUI.Box(panel, GUIContent.none, _reportPanel);
+            GUI.Label(new Rect(478f, 208f, 180f, 94f), report.Grade, _grade);
+            GUI.Label(new Rect(630f, 214f, 470f, 30f), "AFTER-ACTION CONTROL REPORT", _reportTitle);
+            GUI.Label(
+                new Rect(630f, 247f, 470f, 48f),
+                report.Summary,
+                _reportBody);
+
+            string commandLine = report.CommandCount <= 0
+                ? "Reserve commands: none"
+                : "Reserve commands: " + report.CommandCount +
+                  "  //  correct target " + (report.CommandAccuracy * 100f).ToString("0") + "%";
+            GUI.Label(new Rect(478f, 310f, 620f, 24f), commandLine, _muted);
+            GUI.Label(
+                new Rect(478f, 339f, 620f, 54f),
+                "COACH: " + report.Recommendation,
+                _reportBody);
+
+            if (GUI.Button(new Rect(478f, 408f, 150f, 34f), "REPLAY", _strongButton))
+            {
+                _director.StartOrRestartExecution();
+            }
+
+            if (GUI.Button(new Rect(638f, 408f, 150f, 34f), "NEXT ATTACK", _button))
+            {
+                _director.NextPlaybook();
+            }
+
+            string modeLabel = _director.ControlMode == TacticalControlMode.Guided
+                ? "TRY COMMAND"
+                : "WATCH GUIDED";
+            if (GUI.Button(new Rect(798f, 408f, 170f, 34f), modeLabel, _button))
+            {
+                _director.ToggleControlMode();
+                _director.ResetCurrentPlaybook();
+            }
+
+            if (GUI.Button(new Rect(978f, 408f, 144f, 34f), "RESET PLAN", _button))
+            {
+                _director.ResetCurrentPlaybook();
+            }
+        }
+
+        private void EnsureStyles()
+        {
+            if (_stylesReady)
+            {
+                return;
+            }
+
+            Texture2D barTexture = SolidTexture(new Color(0.025f, 0.032f, 0.040f, 0.96f));
+            Texture2D buttonTexture = SolidTexture(new Color(0.11f, 0.14f, 0.17f, 0.98f));
+            Texture2D strongTexture = SolidTexture(new Color(0.92f, 0.48f, 0.18f, 0.98f));
+            Texture2D panelTexture = SolidTexture(new Color(0.025f, 0.032f, 0.040f, 0.985f));
+            Texture2D promptTexture = SolidTexture(new Color(0.34f, 0.12f, 0.08f, 0.97f));
+
+            _bar = new GUIStyle(GUI.skin.box);
+            _bar.normal.background = barTexture;
+            _bar.border = new RectOffset(1, 1, 1, 1);
+
+            _button = new GUIStyle(GUI.skin.button);
+            _button.normal.background = buttonTexture;
+            _button.hover.background = buttonTexture;
+            _button.active.background = strongTexture;
+            _button.normal.textColor = new Color(0.88f, 0.91f, 0.94f);
+            _button.hover.textColor = Color.white;
+            _button.active.textColor = Color.white;
+            _button.alignment = TextAnchor.MiddleCenter;
+            _button.fontSize = 11;
+            _button.fontStyle = FontStyle.Bold;
+            _button.padding = new RectOffset(4, 4, 2, 2);
+
+            _strongButton = new GUIStyle(_button);
+            _strongButton.normal.background = strongTexture;
+            _strongButton.hover.background = strongTexture;
+            _strongButton.normal.textColor = Color.white;
+
+            _label = new GUIStyle(GUI.skin.label);
+            _label.alignment = TextAnchor.MiddleRight;
+            _label.fontSize = 14;
+            _label.fontStyle = FontStyle.Bold;
+            _label.normal.textColor = new Color(0.48f, 0.94f, 0.72f);
+
+            _muted = new GUIStyle(GUI.skin.label);
+            _muted.fontSize = 13;
+            _muted.normal.textColor = new Color(0.58f, 0.64f, 0.69f);
+
+            _prompt = new GUIStyle(GUI.skin.box);
+            _prompt.normal.background = promptTexture;
+            _prompt.normal.textColor = new Color(1f, 0.91f, 0.75f);
+            _prompt.alignment = TextAnchor.MiddleCenter;
+            _prompt.fontSize = 15;
+            _prompt.fontStyle = FontStyle.Bold;
+            _prompt.padding = new RectOffset(12, 12, 8, 8);
+
+            _reportPanel = new GUIStyle(GUI.skin.box);
+            _reportPanel.normal.background = panelTexture;
+            _reportPanel.padding = new RectOffset(18, 18, 18, 18);
+
+            _grade = new GUIStyle(GUI.skin.label);
+            _grade.fontSize = 76;
+            _grade.fontStyle = FontStyle.Bold;
+            _grade.alignment = TextAnchor.MiddleCenter;
+            _grade.normal.textColor = new Color(1.00f, 0.63f, 0.20f);
+
+            _reportTitle = new GUIStyle(GUI.skin.label);
+            _reportTitle.fontSize = 20;
+            _reportTitle.fontStyle = FontStyle.Bold;
+            _reportTitle.normal.textColor = Color.white;
+
+            _reportBody = new GUIStyle(GUI.skin.label);
+            _reportBody.fontSize = 14;
+            _reportBody.wordWrap = true;
+            _reportBody.normal.textColor = new Color(0.82f, 0.86f, 0.90f);
+
+            _stylesReady = true;
+        }
+
+        private static string ShortRouteName(string routeId)
+        {
+            if (routeId == GlasshouseScenario.CrimsonRouteId) return "CRIMSON";
+            if (routeId == GlasshouseScenario.ServiceRouteId) return "SERVICE";
+            if (routeId == GlasshouseScenario.ColdHatchRouteId) return "COLD";
+            return routeId.ToUpperInvariant();
+        }
+
+        private static Texture2D SolidTexture(Color color)
+        {
+            Texture2D texture = new Texture2D(1, 1, TextureFormat.RGBA32, false);
+            texture.name = "Tactical HUD " + ColorUtility.ToHtmlStringRGBA(color);
+            texture.SetPixel(0, 0, color);
+            texture.Apply();
+            return texture;
+        }
+    }
+}

--- a/Assets/Scripts/TacticalSquad/TacticalCommandHud.cs.meta
+++ b/Assets/Scripts/TacticalSquad/TacticalCommandHud.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e7cf14856ef943eeb66c94b4c40fe330
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/TacticalSquad/TacticalMissionScoring.cs
+++ b/Assets/Scripts/TacticalSquad/TacticalMissionScoring.cs
@@ -1,0 +1,286 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Sipoga.Tactics
+{
+    public enum TacticalControlMode
+    {
+        Guided,
+        Command
+    }
+
+    public sealed class TacticalMissionReport
+    {
+        public float ControlPercent;
+        public float WeightedThreatSeconds;
+        public float WeightedExposureSeconds;
+        public float LongestBreakSeconds;
+        public int RepairCount;
+        public int CommandCount;
+        public int CorrectCommandCount;
+        public int UnansweredRoutes;
+        public string Grade;
+        public string Summary;
+        public string Recommendation;
+
+        public float CommandAccuracy
+        {
+            get
+            {
+                return CommandCount <= 0
+                    ? 0f
+                    : CorrectCommandCount / (float)CommandCount;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Converts the tactical state graph into an understandable mission result.
+    /// A route only costs score while attackers are applying pressure, and the
+    /// penalty is proportional to both pressure and the fraction of missing promises.
+    /// </summary>
+    public sealed class TacticalMissionScorer
+    {
+        private readonly TacticalScenarioDefinition _scenario;
+        private readonly Dictionary<string, float> _routeExposure =
+            new Dictionary<string, float>();
+        private readonly Dictionary<string, float> _breakStartedAt =
+            new Dictionary<string, float>();
+
+        private float _weightedThreatSeconds;
+        private float _weightedExposureSeconds;
+        private float _longestBreakSeconds;
+        private int _repairCount;
+        private int _commandCount;
+        private int _correctCommandCount;
+        private bool _running;
+        private bool _finished;
+        private TacticalEvaluation _lastEvaluation;
+
+        public TacticalMissionScorer(TacticalScenarioDefinition scenario)
+        {
+            _scenario = scenario;
+            Reset();
+        }
+
+        public void Reset()
+        {
+            _routeExposure.Clear();
+            _breakStartedAt.Clear();
+            for (int i = 0; i < _scenario.Routes.Count; i++)
+            {
+                _routeExposure[_scenario.Routes[i].Id] = 0f;
+            }
+
+            _weightedThreatSeconds = 0f;
+            _weightedExposureSeconds = 0f;
+            _longestBreakSeconds = 0f;
+            _repairCount = 0;
+            _commandCount = 0;
+            _correctCommandCount = 0;
+            _running = false;
+            _finished = false;
+            _lastEvaluation = null;
+        }
+
+        public void Begin()
+        {
+            _running = true;
+            _finished = false;
+        }
+
+        public void Tick(float deltaTime, float executionTime, TacticalEvaluation evaluation)
+        {
+            if (!_running || _finished || evaluation == null || deltaTime <= 0f)
+            {
+                return;
+            }
+
+            _lastEvaluation = evaluation;
+            float intervalStart = Mathf.Max(0f, executionTime - deltaTime);
+            for (int i = 0; i < evaluation.Routes.Count; i++)
+            {
+                TacticalRouteRuntimeState route = evaluation.Routes[i];
+                float pressure = Mathf.Max(0f, route.Pressure);
+                if (pressure <= 0f)
+                {
+                    CloseBreak(route.RouteId, intervalStart, false);
+                    continue;
+                }
+
+                _weightedThreatSeconds += pressure * deltaTime;
+                int missingPromises = Mathf.Max(0, route.RequiredCoverage - route.Coverage);
+                float deficitFraction = route.RequiredCoverage <= 0
+                    ? 0f
+                    : missingPromises / (float)route.RequiredCoverage;
+                float exposure = pressure * deficitFraction * deltaTime;
+                _weightedExposureSeconds += exposure;
+                _routeExposure[route.RouteId] = _routeExposure[route.RouteId] + exposure;
+
+                if (missingPromises > 0)
+                {
+                    float startedAt;
+                    if (!_breakStartedAt.TryGetValue(route.RouteId, out startedAt))
+                    {
+                        startedAt = intervalStart;
+                        _breakStartedAt[route.RouteId] = startedAt;
+                    }
+
+                    _longestBreakSeconds = Mathf.Max(
+                        _longestBreakSeconds,
+                        Mathf.Max(0f, executionTime - startedAt));
+                }
+                else
+                {
+                    CloseBreak(route.RouteId, intervalStart, true);
+                }
+            }
+        }
+
+        public void RecordCommand(string routeId, TacticalFlexDirective recommended)
+        {
+            _commandCount++;
+            if (recommended != null && recommended.IsActive && recommended.RouteId == routeId)
+            {
+                _correctCommandCount++;
+            }
+        }
+
+        public void Finish(TacticalEvaluation evaluation)
+        {
+            _lastEvaluation = evaluation;
+            _running = false;
+            _finished = true;
+        }
+
+        public TacticalMissionReport BuildReport(float executionTime)
+        {
+            TacticalMissionReport report = new TacticalMissionReport();
+            report.WeightedThreatSeconds = _weightedThreatSeconds;
+            report.WeightedExposureSeconds = _weightedExposureSeconds;
+            report.LongestBreakSeconds = GetLongestBreakIncludingOpen(executionTime);
+            report.RepairCount = _repairCount;
+            report.CommandCount = _commandCount;
+            report.CorrectCommandCount = _correctCommandCount;
+            report.UnansweredRoutes = CountUnansweredRoutes(_lastEvaluation);
+            report.ControlPercent = _weightedThreatSeconds <= 0.001f
+                ? 100f
+                : Mathf.Clamp01(1f - _weightedExposureSeconds / _weightedThreatSeconds) * 100f;
+
+            float gradeScore = report.ControlPercent;
+            gradeScore -= Mathf.Max(0f, report.LongestBreakSeconds - 3f) * 1.25f;
+            gradeScore -= report.UnansweredRoutes * 8f;
+            if (report.CommandCount > 0)
+            {
+                gradeScore -= (1f - report.CommandAccuracy) * 8f;
+            }
+
+            report.Grade = GradeFor(gradeScore);
+            report.Summary =
+                "You preserved " + report.ControlPercent.ToString("0") +
+                "% of pressure-weighted map control. " +
+                report.RepairCount + " route repair" +
+                (report.RepairCount == 1 ? string.Empty : "s") +
+                ", longest active break " + report.LongestBreakSeconds.ToString("0.0") + "s.";
+            report.Recommendation = BuildRecommendation(report);
+            return report;
+        }
+
+        private float GetLongestBreakIncludingOpen(float executionTime)
+        {
+            float longest = _longestBreakSeconds;
+            foreach (KeyValuePair<string, float> pair in _breakStartedAt)
+            {
+                longest = Mathf.Max(longest, Mathf.Max(0f, executionTime - pair.Value));
+            }
+
+            return longest;
+        }
+
+        private int CountUnansweredRoutes(TacticalEvaluation evaluation)
+        {
+            if (evaluation == null)
+            {
+                return 0;
+            }
+
+            int count = 0;
+            for (int i = 0; i < evaluation.Routes.Count; i++)
+            {
+                TacticalRouteRuntimeState route = evaluation.Routes[i];
+                if (route.Pressure > 0 && !route.IsSecured)
+                {
+                    count++;
+                }
+            }
+
+            return count;
+        }
+
+        private string BuildRecommendation(TacticalMissionReport report)
+        {
+            string worstRouteId = string.Empty;
+            float worstExposure = 0f;
+            foreach (KeyValuePair<string, float> pair in _routeExposure)
+            {
+                if (pair.Value > worstExposure)
+                {
+                    worstExposure = pair.Value;
+                    worstRouteId = pair.Key;
+                }
+            }
+
+            if (string.IsNullOrEmpty(worstRouteId) || worstExposure <= 0.01f)
+            {
+                return "No pressured route accumulated meaningful exposure. Try Command mode and deliberately break a promise to study the repair loop.";
+            }
+
+            TacticalRouteDefinition route = FindRoute(worstRouteId);
+            string routeLabel = route != null ? route.Label : worstRouteId;
+            string commandNote = report.CommandCount == 0
+                ? " Issue the reserve order as soon as the route turns orange."
+                : report.CommandAccuracy < 0.75f
+                    ? " Watch the recommended route before committing the reserve."
+                    : " Your target choice was sound; shorten the travel delay.";
+            return routeLabel + " created the most exposure." + commandNote;
+        }
+
+        private TacticalRouteDefinition FindRoute(string routeId)
+        {
+            for (int i = 0; i < _scenario.Routes.Count; i++)
+            {
+                if (_scenario.Routes[i].Id == routeId)
+                {
+                    return _scenario.Routes[i];
+                }
+            }
+
+            return null;
+        }
+
+        private void CloseBreak(string routeId, float closedAt, bool countAsRepair)
+        {
+            float startedAt;
+            if (_breakStartedAt.TryGetValue(routeId, out startedAt))
+            {
+                _longestBreakSeconds = Mathf.Max(
+                    _longestBreakSeconds,
+                    Mathf.Max(0f, closedAt - startedAt));
+                _breakStartedAt.Remove(routeId);
+                if (countAsRepair)
+                {
+                    _repairCount++;
+                }
+            }
+        }
+
+        private static string GradeFor(float score)
+        {
+            if (score >= 95f) return "S";
+            if (score >= 87f) return "A";
+            if (score >= 74f) return "B";
+            if (score >= 58f) return "C";
+            return "D";
+        }
+    }
+}

--- a/Assets/Scripts/TacticalSquad/TacticalMissionScoring.cs.meta
+++ b/Assets/Scripts/TacticalSquad/TacticalMissionScoring.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5dc9472554d846bdac3aa5fb2c6d5d21
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/TacticalSquad/TacticalModel.cs
+++ b/Assets/Scripts/TacticalSquad/TacticalModel.cs
@@ -1,0 +1,1150 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Sipoga.Tactics
+{
+    public enum TacticalSurfaceState
+    {
+        Permeable,
+        Open,
+        Sealed
+    }
+
+    public enum TacticalUnitCondition
+    {
+        Active,
+        Down
+    }
+
+    public enum TacticalResponsibilityKind
+    {
+        HoldAngle,
+        DenyRoute,
+        DenySurface,
+        Crossfire,
+        Delay,
+        Reserve
+    }
+
+    public enum TacticalAttackAction
+    {
+        Log,
+        SetPressure,
+        SetSurfaceState,
+        SetUnitDown
+    }
+
+    [Serializable]
+    public sealed class TacticalPositionDefinition
+    {
+        public string Id;
+        public string Label;
+        public Vector3 WorldPosition;
+        public int Floor;
+
+        public TacticalPositionDefinition(string id, string label, Vector3 worldPosition, int floor)
+        {
+            Id = id;
+            Label = label;
+            WorldPosition = worldPosition;
+            Floor = floor;
+        }
+    }
+
+    [Serializable]
+    public sealed class TacticalRouteDefinition
+    {
+        public string Id;
+        public string Label;
+        public string Description;
+        public int RequiredCoverage;
+        public Vector3 Start;
+        public Vector3 End;
+
+        public TacticalRouteDefinition(
+            string id,
+            string label,
+            string description,
+            int requiredCoverage,
+            Vector3 start,
+            Vector3 end)
+        {
+            Id = id;
+            Label = label;
+            Description = description;
+            RequiredCoverage = requiredCoverage;
+            Start = start;
+            End = end;
+        }
+
+        public Vector3 Midpoint
+        {
+            get { return Vector3.Lerp(Start, End, 0.5f); }
+        }
+    }
+
+    [Serializable]
+    public sealed class TacticalSurfaceDefinition
+    {
+        public string Id;
+        public string Label;
+        public TacticalSurfaceState DefaultState;
+        public Vector3 WorldPosition;
+        public Vector3 WorldScale;
+
+        public TacticalSurfaceDefinition(
+            string id,
+            string label,
+            TacticalSurfaceState defaultState,
+            Vector3 worldPosition,
+            Vector3 worldScale)
+        {
+            Id = id;
+            Label = label;
+            DefaultState = defaultState;
+            WorldPosition = worldPosition;
+            WorldScale = worldScale;
+        }
+    }
+
+    [Serializable]
+    public sealed class TacticalUnitPlan
+    {
+        public string UnitId;
+        public string Callsign;
+        public string RoleLabel;
+        public TacticalResponsibilityKind ResponsibilityKind;
+        public string HomePositionId;
+        public string FallbackPositionId;
+        public string ExecutePositionId;
+        public bool IsFlex;
+        public Color DisplayColor;
+        public string WhatText;
+        public string WhySafeText;
+        public string BreakText;
+        public string FallbackText;
+
+        public TacticalUnitPlan(
+            string unitId,
+            string callsign,
+            string roleLabel,
+            TacticalResponsibilityKind responsibilityKind,
+            string homePositionId,
+            string fallbackPositionId,
+            string executePositionId,
+            bool isFlex,
+            Color displayColor,
+            string whatText,
+            string whySafeText,
+            string breakText,
+            string fallbackText)
+        {
+            UnitId = unitId;
+            Callsign = callsign;
+            RoleLabel = roleLabel;
+            ResponsibilityKind = responsibilityKind;
+            HomePositionId = homePositionId;
+            FallbackPositionId = fallbackPositionId;
+            ExecutePositionId = executePositionId;
+            IsFlex = isFlex;
+            DisplayColor = displayColor;
+            WhatText = whatText;
+            WhySafeText = whySafeText;
+            BreakText = breakText;
+            FallbackText = fallbackText;
+        }
+    }
+
+    [Serializable]
+    public sealed class TacticalCoverageRule
+    {
+        public string Id;
+        public string UnitId;
+        public string RouteId;
+        public string PositionId;
+        public string RequiredSurfaceId;
+        public TacticalSurfaceState[] AllowedSurfaceStates;
+        public string Explanation;
+
+        public TacticalCoverageRule(
+            string id,
+            string unitId,
+            string routeId,
+            string positionId,
+            string explanation)
+            : this(
+                id,
+                unitId,
+                routeId,
+                positionId,
+                string.Empty,
+                new TacticalSurfaceState[0],
+                explanation)
+        {
+        }
+
+        public TacticalCoverageRule(
+            string id,
+            string unitId,
+            string routeId,
+            string positionId,
+            string requiredSurfaceId,
+            TacticalSurfaceState[] allowedSurfaceStates,
+            string explanation)
+        {
+            Id = id;
+            UnitId = unitId;
+            RouteId = routeId;
+            PositionId = positionId;
+            RequiredSurfaceId = requiredSurfaceId;
+            AllowedSurfaceStates = allowedSurfaceStates ?? new TacticalSurfaceState[0];
+            Explanation = explanation;
+        }
+    }
+
+    [Serializable]
+    public sealed class TacticalFlexOption
+    {
+        public string RouteId;
+        public string PositionId;
+        public string ResponsibilityLabel;
+        public int Priority;
+        public string Explanation;
+
+        public TacticalFlexOption(
+            string routeId,
+            string positionId,
+            string responsibilityLabel,
+            int priority,
+            string explanation)
+        {
+            RouteId = routeId;
+            PositionId = positionId;
+            ResponsibilityLabel = responsibilityLabel;
+            Priority = priority;
+            Explanation = explanation;
+        }
+    }
+
+    [Serializable]
+    public sealed class TacticalAttackStep
+    {
+        public float Time;
+        public TacticalAttackAction Action;
+        public string TargetId;
+        public int IntValue;
+        public TacticalSurfaceState SurfaceState;
+        public bool BoolValue;
+        public string Message;
+
+        public TacticalAttackStep(
+            float time,
+            TacticalAttackAction action,
+            string targetId,
+            int intValue,
+            TacticalSurfaceState surfaceState,
+            bool boolValue,
+            string message)
+        {
+            Time = time;
+            Action = action;
+            TargetId = targetId;
+            IntValue = intValue;
+            SurfaceState = surfaceState;
+            BoolValue = boolValue;
+            Message = message;
+        }
+
+        public static TacticalAttackStep Log(float time, string message)
+        {
+            return new TacticalAttackStep(
+                time,
+                TacticalAttackAction.Log,
+                string.Empty,
+                0,
+                TacticalSurfaceState.Permeable,
+                false,
+                message);
+        }
+
+        public static TacticalAttackStep Pressure(float time, string routeId, int pressure, string message)
+        {
+            return new TacticalAttackStep(
+                time,
+                TacticalAttackAction.SetPressure,
+                routeId,
+                pressure,
+                TacticalSurfaceState.Permeable,
+                false,
+                message);
+        }
+
+        public static TacticalAttackStep Surface(
+            float time,
+            string surfaceId,
+            TacticalSurfaceState state,
+            string message)
+        {
+            return new TacticalAttackStep(
+                time,
+                TacticalAttackAction.SetSurfaceState,
+                surfaceId,
+                0,
+                state,
+                false,
+                message);
+        }
+
+        public static TacticalAttackStep UnitDown(float time, string unitId, bool down, string message)
+        {
+            return new TacticalAttackStep(
+                time,
+                TacticalAttackAction.SetUnitDown,
+                unitId,
+                0,
+                TacticalSurfaceState.Permeable,
+                down,
+                message);
+        }
+    }
+
+    [Serializable]
+    public sealed class TacticalAttackPlaybook
+    {
+        public string Id;
+        public string Name;
+        public string Summary;
+        public string Lesson;
+        public float Duration;
+        public List<TacticalAttackStep> Steps = new List<TacticalAttackStep>();
+
+        public TacticalAttackPlaybook(
+            string id,
+            string name,
+            string summary,
+            string lesson,
+            float duration)
+        {
+            Id = id;
+            Name = name;
+            Summary = summary;
+            Lesson = lesson;
+            Duration = duration;
+        }
+    }
+
+    [Serializable]
+    public sealed class TacticalScenarioDefinition
+    {
+        public string Id;
+        public string DisplayName;
+        public string Revision;
+        public string Description;
+        public List<TacticalPositionDefinition> Positions = new List<TacticalPositionDefinition>();
+        public List<TacticalRouteDefinition> Routes = new List<TacticalRouteDefinition>();
+        public List<TacticalSurfaceDefinition> Surfaces = new List<TacticalSurfaceDefinition>();
+        public List<TacticalUnitPlan> Units = new List<TacticalUnitPlan>();
+        public List<TacticalCoverageRule> CoverageRules = new List<TacticalCoverageRule>();
+        public List<TacticalFlexOption> FlexOptions = new List<TacticalFlexOption>();
+        public List<TacticalAttackPlaybook> AttackPlaybooks = new List<TacticalAttackPlaybook>();
+
+        public TacticalScenarioDefinition(string id, string displayName, string revision, string description)
+        {
+            Id = id;
+            DisplayName = displayName;
+            Revision = revision;
+            Description = description;
+        }
+    }
+
+    public sealed class TacticalUnitRuntimeState
+    {
+        public string UnitId;
+        public string PositionId;
+        public TacticalUnitCondition Condition;
+        public bool IsInTransit;
+
+        public TacticalUnitRuntimeState(string unitId, string positionId)
+        {
+            UnitId = unitId;
+            PositionId = positionId;
+            Condition = TacticalUnitCondition.Active;
+            IsInTransit = false;
+        }
+    }
+
+    public sealed class TacticalRouteRuntimeState
+    {
+        public string RouteId;
+        public int BaselineCoverage;
+        public int Coverage;
+        public int RequiredCoverage;
+        public int Pressure;
+        public bool IsBeingRepaired;
+        public bool IsFlexHolding;
+        public bool IsSecured;
+        public List<string> Contributors = new List<string>();
+
+        public string StatusLabel
+        {
+            get
+            {
+                if (IsSecured)
+                {
+                    return IsFlexHolding ? "REPAIRED" : "SECURED";
+                }
+
+                return IsBeingRepaired ? "REPAIRING" : "BROKEN";
+            }
+        }
+    }
+
+    public sealed class TacticalFlexDirective
+    {
+        public bool IsActive;
+        public string UnitId;
+        public string RouteId;
+        public string PositionId;
+        public string ResponsibilityLabel;
+        public string Explanation;
+
+        public static TacticalFlexDirective ReturnToReserve(string unitId, string positionId)
+        {
+            TacticalFlexDirective directive = new TacticalFlexDirective();
+            directive.IsActive = false;
+            directive.UnitId = unitId;
+            directive.RouteId = string.Empty;
+            directive.PositionId = positionId;
+            directive.ResponsibilityLabel = "Reserve";
+            directive.Explanation = "All baseline promises are intact. Return to reserve and wait for the first failure.";
+            return directive;
+        }
+    }
+
+    public sealed class TacticalExplanation
+    {
+        public string What;
+        public string WhySafe;
+        public string WhatBreaksIt;
+        public string Fallback;
+    }
+
+    public sealed class TacticalEvaluation
+    {
+        public readonly List<TacticalRouteRuntimeState> Routes;
+        public readonly TacticalFlexDirective FlexDirective;
+
+        public TacticalEvaluation(
+            List<TacticalRouteRuntimeState> routes,
+            TacticalFlexDirective flexDirective)
+        {
+            Routes = routes;
+            FlexDirective = flexDirective;
+        }
+
+        public TacticalRouteRuntimeState GetRoute(string routeId)
+        {
+            for (int i = 0; i < Routes.Count; i++)
+            {
+                if (Routes[i].RouteId == routeId)
+                {
+                    return Routes[i];
+                }
+            }
+
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Pure tactical state evaluator. It deliberately knows nothing about cameras,
+    /// animation, navigation, rendering, or weapons. That lets the same authored
+    /// strategy drive gameplay, overlays, explanations, tests, and replays.
+    /// </summary>
+    public sealed class TacticalStateEngine
+    {
+        private readonly TacticalScenarioDefinition _scenario;
+        private readonly Dictionary<string, TacticalPositionDefinition> _positions =
+            new Dictionary<string, TacticalPositionDefinition>();
+        private readonly Dictionary<string, TacticalRouteDefinition> _routes =
+            new Dictionary<string, TacticalRouteDefinition>();
+        private readonly Dictionary<string, TacticalSurfaceDefinition> _surfaceDefinitions =
+            new Dictionary<string, TacticalSurfaceDefinition>();
+        private readonly Dictionary<string, TacticalUnitPlan> _unitPlans =
+            new Dictionary<string, TacticalUnitPlan>();
+        private readonly Dictionary<string, TacticalUnitRuntimeState> _units =
+            new Dictionary<string, TacticalUnitRuntimeState>();
+        private readonly Dictionary<string, TacticalSurfaceState> _surfaces =
+            new Dictionary<string, TacticalSurfaceState>();
+        private readonly Dictionary<string, int> _routePressure =
+            new Dictionary<string, int>();
+
+        private string _lastFlexRouteId = string.Empty;
+
+        public TacticalStateEngine(TacticalScenarioDefinition scenario)
+        {
+            if (scenario == null)
+            {
+                throw new ArgumentNullException("scenario");
+            }
+
+            _scenario = scenario;
+            IndexScenario();
+            Reset();
+        }
+
+        public TacticalScenarioDefinition Scenario
+        {
+            get { return _scenario; }
+        }
+
+        public void Reset()
+        {
+            _units.Clear();
+            for (int i = 0; i < _scenario.Units.Count; i++)
+            {
+                TacticalUnitPlan plan = _scenario.Units[i];
+                _units.Add(plan.UnitId, new TacticalUnitRuntimeState(plan.UnitId, plan.HomePositionId));
+            }
+
+            _surfaces.Clear();
+            for (int i = 0; i < _scenario.Surfaces.Count; i++)
+            {
+                TacticalSurfaceDefinition surface = _scenario.Surfaces[i];
+                _surfaces.Add(surface.Id, surface.DefaultState);
+            }
+
+            _routePressure.Clear();
+            for (int i = 0; i < _scenario.Routes.Count; i++)
+            {
+                _routePressure.Add(_scenario.Routes[i].Id, 0);
+            }
+
+            _lastFlexRouteId = string.Empty;
+        }
+
+        public TacticalUnitRuntimeState GetUnitState(string unitId)
+        {
+            TacticalUnitRuntimeState state;
+            return _units.TryGetValue(unitId, out state) ? state : null;
+        }
+
+        public TacticalUnitPlan GetUnitPlan(string unitId)
+        {
+            TacticalUnitPlan plan;
+            return _unitPlans.TryGetValue(unitId, out plan) ? plan : null;
+        }
+
+        public TacticalPositionDefinition GetPosition(string positionId)
+        {
+            TacticalPositionDefinition position;
+            return _positions.TryGetValue(positionId, out position) ? position : null;
+        }
+
+        public TacticalRouteDefinition GetRouteDefinition(string routeId)
+        {
+            TacticalRouteDefinition route;
+            return _routes.TryGetValue(routeId, out route) ? route : null;
+        }
+
+        public TacticalSurfaceState GetSurfaceState(string surfaceId)
+        {
+            TacticalSurfaceState state;
+            if (!_surfaces.TryGetValue(surfaceId, out state))
+            {
+                throw new ArgumentException("Unknown tactical surface: " + surfaceId);
+            }
+
+            return state;
+        }
+
+        public int GetRoutePressure(string routeId)
+        {
+            int pressure;
+            return _routePressure.TryGetValue(routeId, out pressure) ? pressure : 0;
+        }
+
+        public void SetUnitPosition(string unitId, string positionId)
+        {
+            TacticalUnitRuntimeState unit = RequireUnit(unitId);
+            RequirePosition(positionId);
+            unit.PositionId = positionId;
+            unit.IsInTransit = false;
+        }
+
+        public void MarkUnitInTransit(string unitId)
+        {
+            TacticalUnitRuntimeState unit = RequireUnit(unitId);
+            unit.PositionId = string.Empty;
+            unit.IsInTransit = true;
+        }
+
+        public void SetUnitDown(string unitId, bool down)
+        {
+            TacticalUnitRuntimeState unit = RequireUnit(unitId);
+            unit.Condition = down ? TacticalUnitCondition.Down : TacticalUnitCondition.Active;
+        }
+
+        public void SetSurfaceState(string surfaceId, TacticalSurfaceState state)
+        {
+            if (!_surfaces.ContainsKey(surfaceId))
+            {
+                throw new ArgumentException("Unknown tactical surface: " + surfaceId);
+            }
+
+            _surfaces[surfaceId] = state;
+        }
+
+        public void SetRoutePressure(string routeId, int pressure)
+        {
+            if (!_routePressure.ContainsKey(routeId))
+            {
+                throw new ArgumentException("Unknown tactical route: " + routeId);
+            }
+
+            _routePressure[routeId] = Mathf.Max(0, pressure);
+        }
+
+        public TacticalEvaluation Evaluate()
+        {
+            Dictionary<string, int> baseline = new Dictionary<string, int>();
+            Dictionary<string, List<string>> contributors = new Dictionary<string, List<string>>();
+
+            for (int i = 0; i < _scenario.Routes.Count; i++)
+            {
+                string routeId = _scenario.Routes[i].Id;
+                baseline[routeId] = 0;
+                contributors[routeId] = new List<string>();
+            }
+
+            for (int i = 0; i < _scenario.CoverageRules.Count; i++)
+            {
+                TacticalCoverageRule rule = _scenario.CoverageRules[i];
+                if (!IsCoverageRuleActive(rule))
+                {
+                    continue;
+                }
+
+                baseline[rule.RouteId] = baseline[rule.RouteId] + 1;
+                contributors[rule.RouteId].Add(rule.UnitId);
+            }
+
+            TacticalUnitPlan flexPlan = FindFlexPlan();
+            TacticalFlexDirective directive = BuildFlexDirective(flexPlan, baseline);
+
+            string physicallyHeldFlexRoute = string.Empty;
+            if (flexPlan != null)
+            {
+                TacticalUnitRuntimeState flexState = _units[flexPlan.UnitId];
+                if (flexState.Condition == TacticalUnitCondition.Active && !flexState.IsInTransit)
+                {
+                    for (int i = 0; i < _scenario.FlexOptions.Count; i++)
+                    {
+                        TacticalFlexOption option = _scenario.FlexOptions[i];
+                        if (flexState.PositionId == option.PositionId)
+                        {
+                            physicallyHeldFlexRoute = option.RouteId;
+                            break;
+                        }
+                    }
+                }
+            }
+
+            List<TacticalRouteRuntimeState> routeStates = new List<TacticalRouteRuntimeState>();
+            for (int i = 0; i < _scenario.Routes.Count; i++)
+            {
+                TacticalRouteDefinition route = _scenario.Routes[i];
+                TacticalRouteRuntimeState routeState = new TacticalRouteRuntimeState();
+                routeState.RouteId = route.Id;
+                routeState.BaselineCoverage = baseline[route.Id];
+                routeState.Coverage = routeState.BaselineCoverage;
+                routeState.RequiredCoverage = route.RequiredCoverage;
+                routeState.Pressure = GetRoutePressure(route.Id);
+                routeState.Contributors.AddRange(contributors[route.Id]);
+
+                if (flexPlan != null && physicallyHeldFlexRoute == route.Id)
+                {
+                    routeState.Coverage += 1;
+                    routeState.IsFlexHolding = true;
+                    routeState.Contributors.Add(flexPlan.UnitId);
+                }
+
+                routeState.IsBeingRepaired =
+                    directive.IsActive &&
+                    directive.RouteId == route.Id &&
+                    !routeState.IsFlexHolding;
+                routeState.IsSecured = routeState.Coverage >= routeState.RequiredCoverage;
+                routeStates.Add(routeState);
+            }
+
+            return new TacticalEvaluation(routeStates, directive);
+        }
+
+        public bool IsCoverageRuleActive(TacticalCoverageRule rule)
+        {
+            TacticalUnitRuntimeState unit;
+            if (!_units.TryGetValue(rule.UnitId, out unit))
+            {
+                return false;
+            }
+
+            if (unit.Condition != TacticalUnitCondition.Active || unit.IsInTransit)
+            {
+                return false;
+            }
+
+            if (unit.PositionId != rule.PositionId)
+            {
+                return false;
+            }
+
+            if (string.IsNullOrEmpty(rule.RequiredSurfaceId))
+            {
+                return true;
+            }
+
+            TacticalSurfaceState state;
+            if (!_surfaces.TryGetValue(rule.RequiredSurfaceId, out state))
+            {
+                return false;
+            }
+
+            for (int i = 0; i < rule.AllowedSurfaceStates.Length; i++)
+            {
+                if (rule.AllowedSurfaceStates[i] == state)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        public TacticalExplanation GetExplanation(string unitId, TacticalEvaluation evaluation)
+        {
+            TacticalUnitPlan plan = GetUnitPlan(unitId);
+            TacticalUnitRuntimeState state = GetUnitState(unitId);
+            if (plan == null || state == null)
+            {
+                return new TacticalExplanation
+                {
+                    What = "Unknown unit.",
+                    WhySafe = string.Empty,
+                    WhatBreaksIt = string.Empty,
+                    Fallback = string.Empty
+                };
+            }
+
+            if (state.Condition == TacticalUnitCondition.Down)
+            {
+                return new TacticalExplanation
+                {
+                    What = "DOWN. This operator's promise is no longer being kept.",
+                    WhySafe = "Teammates must absorb or replace the missing responsibility.",
+                    WhatBreaksIt = "The route remains weak until a flex operator physically reaches a repair position.",
+                    Fallback = plan.FallbackText
+                };
+            }
+
+            if (plan.IsFlex)
+            {
+                TacticalFlexDirective flex = evaluation.FlexDirective;
+                if (flex.IsActive)
+                {
+                    TacticalRouteRuntimeState route = evaluation.GetRoute(flex.RouteId);
+                    string progress = route != null && route.IsFlexHolding
+                        ? "The repair is active."
+                        : "Move to the marked backup position to make the repair real.";
+
+                    return new TacticalExplanation
+                    {
+                        What = flex.ResponsibilityLabel + ". " + progress,
+                        WhySafe = flex.Explanation,
+                        WhatBreaksIt = "A second simultaneous failure can exceed one reserve operator's capacity.",
+                        Fallback = plan.FallbackText
+                    };
+                }
+
+                return new TacticalExplanation
+                {
+                    What = "Remain in reserve and replace the first broken promise.",
+                    WhySafe = "All baseline responsibilities currently meet their required coverage.",
+                    WhatBreaksIt = "A teammate goes down, leaves position, or loses a required sightline.",
+                    Fallback = plan.FallbackText
+                };
+            }
+
+            string prefix = state.IsInTransit
+                ? "MOVING. Coverage from this operator is temporarily absent. "
+                : string.Empty;
+
+            return new TacticalExplanation
+            {
+                What = prefix + plan.WhatText,
+                WhySafe = plan.WhySafeText,
+                WhatBreaksIt = plan.BreakText,
+                Fallback = plan.FallbackText
+            };
+        }
+
+        public string GetCurrentResponsibilityLabel(string unitId, TacticalEvaluation evaluation)
+        {
+            TacticalUnitPlan plan = GetUnitPlan(unitId);
+            if (plan == null)
+            {
+                return "Unknown";
+            }
+
+            TacticalUnitRuntimeState state = GetUnitState(unitId);
+            if (state != null && state.Condition == TacticalUnitCondition.Down)
+            {
+                return "Promise broken";
+            }
+
+            if (plan.IsFlex && evaluation != null && evaluation.FlexDirective.IsActive)
+            {
+                return evaluation.FlexDirective.ResponsibilityLabel;
+            }
+
+            return plan.RoleLabel;
+        }
+
+        public string GetPositionLabel(string unitId)
+        {
+            TacticalUnitRuntimeState unit = GetUnitState(unitId);
+            if (unit == null)
+            {
+                return "Unknown";
+            }
+
+            if (unit.IsInTransit || string.IsNullOrEmpty(unit.PositionId))
+            {
+                return "In transit";
+            }
+
+            TacticalPositionDefinition position = GetPosition(unit.PositionId);
+            return position != null ? position.Label : unit.PositionId;
+        }
+
+        public List<string> GetActiveRulesForUnit(string unitId)
+        {
+            List<string> ruleIds = new List<string>();
+            for (int i = 0; i < _scenario.CoverageRules.Count; i++)
+            {
+                TacticalCoverageRule rule = _scenario.CoverageRules[i];
+                if (rule.UnitId == unitId && IsCoverageRuleActive(rule))
+                {
+                    ruleIds.Add(rule.Id);
+                }
+            }
+
+            return ruleIds;
+        }
+
+        public TacticalPositionDefinition FindNearestPosition(Vector3 worldPosition, int floor, float maxDistance)
+        {
+            TacticalPositionDefinition best = null;
+            float bestDistance = maxDistance;
+            for (int i = 0; i < _scenario.Positions.Count; i++)
+            {
+                TacticalPositionDefinition candidate = _scenario.Positions[i];
+                if (candidate.Floor != floor)
+                {
+                    continue;
+                }
+
+                float distance = Vector3.Distance(worldPosition, candidate.WorldPosition);
+                if (distance <= bestDistance)
+                {
+                    bestDistance = distance;
+                    best = candidate;
+                }
+            }
+
+            return best;
+        }
+
+        private TacticalFlexDirective BuildFlexDirective(
+            TacticalUnitPlan flexPlan,
+            Dictionary<string, int> baseline)
+        {
+            if (flexPlan == null)
+            {
+                return TacticalFlexDirective.ReturnToReserve(string.Empty, string.Empty);
+            }
+
+            TacticalUnitRuntimeState flexState = _units[flexPlan.UnitId];
+            if (flexState.Condition != TacticalUnitCondition.Active)
+            {
+                TacticalFlexDirective unavailable = TacticalFlexDirective.ReturnToReserve(
+                    flexPlan.UnitId,
+                    flexPlan.HomePositionId);
+                unavailable.Explanation = "The reserve operator is down and cannot repair any broken promise.";
+                return unavailable;
+            }
+
+            TacticalFlexOption best = null;
+            int bestScore = int.MinValue;
+            for (int i = 0; i < _scenario.FlexOptions.Count; i++)
+            {
+                TacticalFlexOption option = _scenario.FlexOptions[i];
+                TacticalRouteDefinition route = _routes[option.RouteId];
+                int deficit = route.RequiredCoverage - baseline[route.Id];
+                if (deficit <= 0)
+                {
+                    continue;
+                }
+
+                int pressure = GetRoutePressure(route.Id);
+                int score = pressure * 100 + deficit * 10 + option.Priority;
+                if (option.RouteId == _lastFlexRouteId)
+                {
+                    score += 1;
+                }
+
+                if (!flexState.IsInTransit && flexState.PositionId == option.PositionId)
+                {
+                    score += 2;
+                }
+
+                if (best == null || score > bestScore)
+                {
+                    best = option;
+                    bestScore = score;
+                }
+            }
+
+            if (best == null)
+            {
+                return TacticalFlexDirective.ReturnToReserve(flexPlan.UnitId, flexPlan.HomePositionId);
+            }
+
+            _lastFlexRouteId = best.RouteId;
+            TacticalFlexDirective directive = new TacticalFlexDirective();
+            directive.IsActive = true;
+            directive.UnitId = flexPlan.UnitId;
+            directive.RouteId = best.RouteId;
+            directive.PositionId = best.PositionId;
+            directive.ResponsibilityLabel = best.ResponsibilityLabel;
+            directive.Explanation = best.Explanation;
+            return directive;
+        }
+
+        private TacticalUnitPlan FindFlexPlan()
+        {
+            for (int i = 0; i < _scenario.Units.Count; i++)
+            {
+                if (_scenario.Units[i].IsFlex)
+                {
+                    return _scenario.Units[i];
+                }
+            }
+
+            return null;
+        }
+
+        private TacticalUnitRuntimeState RequireUnit(string unitId)
+        {
+            TacticalUnitRuntimeState unit;
+            if (!_units.TryGetValue(unitId, out unit))
+            {
+                throw new ArgumentException("Unknown tactical unit: " + unitId);
+            }
+
+            return unit;
+        }
+
+        private TacticalPositionDefinition RequirePosition(string positionId)
+        {
+            TacticalPositionDefinition position;
+            if (!_positions.TryGetValue(positionId, out position))
+            {
+                throw new ArgumentException("Unknown tactical position: " + positionId);
+            }
+
+            return position;
+        }
+
+        private void IndexScenario()
+        {
+            for (int i = 0; i < _scenario.Positions.Count; i++)
+            {
+                _positions.Add(_scenario.Positions[i].Id, _scenario.Positions[i]);
+            }
+
+            for (int i = 0; i < _scenario.Routes.Count; i++)
+            {
+                _routes.Add(_scenario.Routes[i].Id, _scenario.Routes[i]);
+            }
+
+            for (int i = 0; i < _scenario.Surfaces.Count; i++)
+            {
+                _surfaceDefinitions.Add(_scenario.Surfaces[i].Id, _scenario.Surfaces[i]);
+            }
+
+            for (int i = 0; i < _scenario.Units.Count; i++)
+            {
+                _unitPlans.Add(_scenario.Units[i].UnitId, _scenario.Units[i]);
+            }
+        }
+    }
+
+    public static class TacticalScenarioValidator
+    {
+        public static List<string> Validate(TacticalScenarioDefinition scenario)
+        {
+            List<string> errors = new List<string>();
+            if (scenario == null)
+            {
+                errors.Add("Scenario is null.");
+                return errors;
+            }
+
+            HashSet<string> positions = CollectIds(
+                scenario.Positions,
+                delegate(TacticalPositionDefinition value) { return value.Id; },
+                "position",
+                errors);
+            HashSet<string> routes = CollectIds(
+                scenario.Routes,
+                delegate(TacticalRouteDefinition value) { return value.Id; },
+                "route",
+                errors);
+            HashSet<string> surfaces = CollectIds(
+                scenario.Surfaces,
+                delegate(TacticalSurfaceDefinition value) { return value.Id; },
+                "surface",
+                errors);
+            HashSet<string> units = CollectIds(
+                scenario.Units,
+                delegate(TacticalUnitPlan value) { return value.UnitId; },
+                "unit",
+                errors);
+
+            int flexCount = 0;
+            for (int i = 0; i < scenario.Units.Count; i++)
+            {
+                TacticalUnitPlan unit = scenario.Units[i];
+                RequireReference(positions, unit.HomePositionId, "Unit " + unit.UnitId + " home", errors);
+                RequireReference(positions, unit.FallbackPositionId, "Unit " + unit.UnitId + " fallback", errors);
+                RequireReference(positions, unit.ExecutePositionId, "Unit " + unit.UnitId + " execute", errors);
+                if (unit.IsFlex)
+                {
+                    flexCount++;
+                }
+            }
+
+            if (flexCount != 1)
+            {
+                errors.Add("Scenario must define exactly one flex unit; found " + flexCount + ".");
+            }
+
+            HashSet<string> ruleIds = new HashSet<string>();
+            for (int i = 0; i < scenario.CoverageRules.Count; i++)
+            {
+                TacticalCoverageRule rule = scenario.CoverageRules[i];
+                if (!ruleIds.Add(rule.Id))
+                {
+                    errors.Add("Duplicate coverage rule id: " + rule.Id + ".");
+                }
+
+                RequireReference(units, rule.UnitId, "Coverage rule " + rule.Id + " unit", errors);
+                RequireReference(routes, rule.RouteId, "Coverage rule " + rule.Id + " route", errors);
+                RequireReference(positions, rule.PositionId, "Coverage rule " + rule.Id + " position", errors);
+                if (!string.IsNullOrEmpty(rule.RequiredSurfaceId))
+                {
+                    RequireReference(
+                        surfaces,
+                        rule.RequiredSurfaceId,
+                        "Coverage rule " + rule.Id + " surface",
+                        errors);
+                    if (rule.AllowedSurfaceStates == null || rule.AllowedSurfaceStates.Length == 0)
+                    {
+                        errors.Add("Coverage rule " + rule.Id + " requires a surface but allows no states.");
+                    }
+                }
+            }
+
+            for (int i = 0; i < scenario.FlexOptions.Count; i++)
+            {
+                TacticalFlexOption option = scenario.FlexOptions[i];
+                RequireReference(routes, option.RouteId, "Flex option route", errors);
+                RequireReference(positions, option.PositionId, "Flex option position", errors);
+            }
+
+            for (int i = 0; i < scenario.Routes.Count; i++)
+            {
+                if (scenario.Routes[i].RequiredCoverage <= 0)
+                {
+                    errors.Add("Route " + scenario.Routes[i].Id + " must require at least one promise.");
+                }
+            }
+
+            for (int i = 0; i < scenario.AttackPlaybooks.Count; i++)
+            {
+                TacticalAttackPlaybook playbook = scenario.AttackPlaybooks[i];
+                float previousTime = -1f;
+                for (int stepIndex = 0; stepIndex < playbook.Steps.Count; stepIndex++)
+                {
+                    TacticalAttackStep step = playbook.Steps[stepIndex];
+                    if (step.Time < previousTime)
+                    {
+                        errors.Add("Playbook " + playbook.Id + " steps are not sorted by time.");
+                    }
+
+                    previousTime = step.Time;
+                    if (step.Action == TacticalAttackAction.SetPressure)
+                    {
+                        RequireReference(routes, step.TargetId, "Playbook pressure target", errors);
+                    }
+                    else if (step.Action == TacticalAttackAction.SetSurfaceState)
+                    {
+                        RequireReference(surfaces, step.TargetId, "Playbook surface target", errors);
+                    }
+                    else if (step.Action == TacticalAttackAction.SetUnitDown)
+                    {
+                        RequireReference(units, step.TargetId, "Playbook unit target", errors);
+                    }
+                }
+            }
+
+            return errors;
+        }
+
+        private static HashSet<string> CollectIds<T>(
+            List<T> values,
+            Func<T, string> idSelector,
+            string kind,
+            List<string> errors)
+        {
+            HashSet<string> ids = new HashSet<string>();
+            for (int i = 0; i < values.Count; i++)
+            {
+                string id = idSelector(values[i]);
+                if (string.IsNullOrEmpty(id))
+                {
+                    errors.Add("A " + kind + " has an empty id.");
+                }
+                else if (!ids.Add(id))
+                {
+                    errors.Add("Duplicate " + kind + " id: " + id + ".");
+                }
+            }
+
+            return ids;
+        }
+
+        private static void RequireReference(
+            HashSet<string> ids,
+            string id,
+            string context,
+            List<string> errors)
+        {
+            if (string.IsNullOrEmpty(id) || !ids.Contains(id))
+            {
+                errors.Add(context + " references unknown id '" + id + "'.");
+            }
+        }
+    }
+}

--- a/Assets/Scripts/TacticalSquad/TacticalModel.cs.meta
+++ b/Assets/Scripts/TacticalSquad/TacticalModel.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7b3010be1cd84dc9bac415c448347734
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/TacticalSquad/TacticalOverlayRenderer.cs
+++ b/Assets/Scripts/TacticalSquad/TacticalOverlayRenderer.cs
@@ -1,0 +1,264 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Sipoga.Tactics
+{
+    public sealed class TacticalOverlayRenderer : MonoBehaviour
+    {
+        private sealed class RouteVisual
+        {
+            public Renderer Band;
+            public TextMesh Label;
+        }
+
+        private TacticalSquadDirector _director;
+        private TacticalScenarioDefinition _scenario;
+        private readonly Dictionary<string, RouteVisual> _routeVisuals =
+            new Dictionary<string, RouteVisual>();
+        private readonly Dictionary<string, LineRenderer> _coverageLines =
+            new Dictionary<string, LineRenderer>();
+        private LineRenderer _flexDirectiveLine;
+        private GameObject _assignedMarker;
+        private GameObject _fallbackMarker;
+        private GameObject _repairMarker;
+
+        private readonly Color _securedColor = new Color(0.20f, 0.90f, 0.66f);
+        private readonly Color _repairedColor = new Color(0.96f, 0.86f, 0.25f);
+        private readonly Color _repairingColor = new Color(1.00f, 0.58f, 0.20f);
+        private readonly Color _brokenColor = new Color(1.00f, 0.20f, 0.28f);
+        private readonly Color _inactiveLineColor = new Color(1.00f, 0.20f, 0.28f);
+
+        public void Initialize(TacticalSquadDirector director)
+        {
+            _director = director;
+            _scenario = director.Scenario;
+            BuildRouteVisuals();
+            BuildCoverageLines();
+            BuildSelectionMarkers();
+        }
+
+        private void Update()
+        {
+            if (_director == null || _director.Evaluation == null)
+            {
+                return;
+            }
+
+            UpdateRoutes();
+            UpdateCoverageLines();
+            UpdateFlexDirective();
+            UpdateSelectionMarkers();
+        }
+
+        private void BuildRouteVisuals()
+        {
+            Transform routeRoot = new GameObject("Route state overlays").transform;
+            routeRoot.SetParent(transform, false);
+
+            for (int i = 0; i < _scenario.Routes.Count; i++)
+            {
+                TacticalRouteDefinition route = _scenario.Routes[i];
+                Vector3 delta = route.End - route.Start;
+                float length = delta.magnitude;
+                GameObject band = TacticalPrototypeVisual.CreateBlock(
+                    route.Label + " route band",
+                    route.Midpoint,
+                    new Vector3(0.42f, 0.045f, length),
+                    _securedColor,
+                    routeRoot,
+                    false);
+                band.transform.rotation = Quaternion.LookRotation(delta.normalized, Vector3.up);
+
+                TextMesh label = TacticalPrototypeVisual.CreateWorldLabel(
+                    route.Label,
+                    route.Midpoint + Vector3.up * 0.58f,
+                    0.047f,
+                    Color.white,
+                    routeRoot);
+
+                RouteVisual visual = new RouteVisual();
+                visual.Band = band.GetComponent<Renderer>();
+                visual.Label = label;
+                _routeVisuals.Add(route.Id, visual);
+            }
+        }
+
+        private void BuildCoverageLines()
+        {
+            Transform lineRoot = new GameObject("Promise lines").transform;
+            lineRoot.SetParent(transform, false);
+            for (int i = 0; i < _scenario.CoverageRules.Count; i++)
+            {
+                TacticalCoverageRule rule = _scenario.CoverageRules[i];
+                TacticalUnitPlan plan = _director.Engine.GetUnitPlan(rule.UnitId);
+                LineRenderer line = TacticalPrototypeVisual.CreateLine(
+                    "Promise " + rule.Id,
+                    0.035f,
+                    plan.DisplayColor,
+                    lineRoot);
+                _coverageLines.Add(rule.Id, line);
+            }
+
+            _flexDirectiveLine = TacticalPrototypeVisual.CreateLine(
+                "Flex reassignment",
+                0.075f,
+                _repairingColor,
+                lineRoot);
+            _flexDirectiveLine.enabled = false;
+        }
+
+        private void BuildSelectionMarkers()
+        {
+            _assignedMarker = TacticalPrototypeVisual.CreateCylinder(
+                "Selected assignment marker",
+                Vector3.zero,
+                new Vector3(0.42f, 0.025f, 0.42f),
+                Color.white,
+                transform,
+                false);
+            _fallbackMarker = TacticalPrototypeVisual.CreateCylinder(
+                "Selected fallback marker",
+                Vector3.zero,
+                new Vector3(0.34f, 0.020f, 0.34f),
+                new Color(0.52f, 0.58f, 0.64f),
+                transform,
+                false);
+            _repairMarker = TacticalPrototypeVisual.CreateCylinder(
+                "Flex repair marker",
+                Vector3.zero,
+                new Vector3(0.52f, 0.025f, 0.52f),
+                _repairingColor,
+                transform,
+                false);
+        }
+
+        private void UpdateRoutes()
+        {
+            for (int i = 0; i < _director.Evaluation.Routes.Count; i++)
+            {
+                TacticalRouteRuntimeState routeState = _director.Evaluation.Routes[i];
+                RouteVisual visual = _routeVisuals[routeState.RouteId];
+                Color color;
+                if (routeState.IsSecured)
+                {
+                    color = routeState.IsFlexHolding ? _repairedColor : _securedColor;
+                }
+                else
+                {
+                    color = routeState.IsBeingRepaired ? _repairingColor : _brokenColor;
+                }
+
+                visual.Band.sharedMaterial = TacticalPrototypeVisual.GetMaterial(color, true);
+                TacticalRouteDefinition route = _director.Engine.GetRouteDefinition(routeState.RouteId);
+                visual.Label.color = color;
+                visual.Label.text =
+                    route.Label + "\n" +
+                    routeState.Coverage + "/" + routeState.RequiredCoverage + "  " +
+                    routeState.StatusLabel +
+                    (routeState.Pressure > 0 ? "  PRESSURE " + routeState.Pressure : string.Empty);
+            }
+        }
+
+        private void UpdateCoverageLines()
+        {
+            for (int i = 0; i < _scenario.CoverageRules.Count; i++)
+            {
+                TacticalCoverageRule rule = _scenario.CoverageRules[i];
+                LineRenderer line = _coverageLines[rule.Id];
+                TacticalUnitAgent agent = _director.GetAgent(rule.UnitId);
+                TacticalRouteDefinition route = _director.Engine.GetRouteDefinition(rule.RouteId);
+                if (agent == null || route == null)
+                {
+                    line.enabled = false;
+                    continue;
+                }
+
+                bool active = _director.Engine.IsCoverageRuleActive(rule);
+                bool selectedAndBroken =
+                    _director.SelectedUnitId == rule.UnitId &&
+                    !active &&
+                    !agent.IsDown;
+                line.enabled = active || selectedAndBroken;
+                if (!line.enabled)
+                {
+                    continue;
+                }
+
+                Color color = active ? agent.Plan.DisplayColor : _inactiveLineColor;
+                line.sharedMaterial = TacticalPrototypeVisual.GetMaterial(color, true);
+                float width = _director.SelectedUnitId == rule.UnitId ? 0.075f : 0.035f;
+                line.startWidth = width;
+                line.endWidth = width;
+                line.SetPosition(0, agent.transform.position + Vector3.up * 0.80f);
+                line.SetPosition(1, route.Midpoint + Vector3.up * 0.18f);
+            }
+        }
+
+        private void UpdateFlexDirective()
+        {
+            TacticalFlexDirective directive = _director.Evaluation.FlexDirective;
+            TacticalUnitAgent flex = _director.GetAgent(GlasshouseScenario.FlexUnitId);
+            if (flex == null || !directive.IsActive || flex.IsDown)
+            {
+                _flexDirectiveLine.enabled = false;
+                _repairMarker.SetActive(false);
+                return;
+            }
+
+            TacticalPositionDefinition target = _director.Engine.GetPosition(directive.PositionId);
+            TacticalRouteRuntimeState routeState = _director.Evaluation.GetRoute(directive.RouteId);
+            if (target == null || routeState == null)
+            {
+                _flexDirectiveLine.enabled = false;
+                _repairMarker.SetActive(false);
+                return;
+            }
+
+            Color color = routeState.IsFlexHolding ? _repairedColor : _repairingColor;
+            _flexDirectiveLine.enabled = true;
+            _flexDirectiveLine.sharedMaterial = TacticalPrototypeVisual.GetMaterial(color, true);
+            _flexDirectiveLine.startWidth = 0.08f;
+            _flexDirectiveLine.endWidth = 0.08f;
+            _flexDirectiveLine.SetPosition(0, flex.transform.position + Vector3.up * 0.95f);
+            _flexDirectiveLine.SetPosition(1, target.WorldPosition + Vector3.up * 0.18f);
+
+            _repairMarker.SetActive(true);
+            _repairMarker.transform.position = target.WorldPosition + Vector3.down * 0.92f;
+            Renderer markerRenderer = _repairMarker.GetComponent<Renderer>();
+            markerRenderer.sharedMaterial = TacticalPrototypeVisual.GetMaterial(color, true);
+        }
+
+        private void UpdateSelectionMarkers()
+        {
+            TacticalUnitPlan plan = _director.Engine.GetUnitPlan(_director.SelectedUnitId);
+            if (plan == null)
+            {
+                _assignedMarker.SetActive(false);
+                _fallbackMarker.SetActive(false);
+                return;
+            }
+
+            string assignedPositionId = plan.HomePositionId;
+            if (plan.IsFlex && _director.Evaluation.FlexDirective.IsActive)
+            {
+                assignedPositionId = _director.Evaluation.FlexDirective.PositionId;
+            }
+
+            TacticalPositionDefinition assigned = _director.Engine.GetPosition(assignedPositionId);
+            TacticalPositionDefinition fallback = _director.Engine.GetPosition(plan.FallbackPositionId);
+            _assignedMarker.SetActive(assigned != null);
+            _fallbackMarker.SetActive(fallback != null);
+            if (assigned != null)
+            {
+                _assignedMarker.transform.position = assigned.WorldPosition + Vector3.down * 0.91f;
+                _assignedMarker.GetComponent<Renderer>().sharedMaterial =
+                    TacticalPrototypeVisual.GetMaterial(plan.DisplayColor, true);
+            }
+
+            if (fallback != null)
+            {
+                _fallbackMarker.transform.position = fallback.WorldPosition + Vector3.down * 0.92f;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/TacticalSquad/TacticalOverlayRenderer.cs.meta
+++ b/Assets/Scripts/TacticalSquad/TacticalOverlayRenderer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4fe9ddc110bd4df0ac72c18c360c8b5a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/TacticalSquad/TacticalPrototypeBootstrap.cs
+++ b/Assets/Scripts/TacticalSquad/TacticalPrototypeBootstrap.cs
@@ -1,0 +1,84 @@
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+namespace Sipoga.Tactics
+{
+    public sealed class TacticalPrototypeBootstrap : MonoBehaviour
+    {
+        private const string PrototypeSceneName = "TacticalSquadPrototype";
+
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
+        private static void LaunchPrototypeScene()
+        {
+            Scene activeScene = SceneManager.GetActiveScene();
+            if (activeScene.name != PrototypeSceneName)
+            {
+                return;
+            }
+
+            if (FindObjectOfType<TacticalPrototypeBootstrap>() != null)
+            {
+                return;
+            }
+
+            GameObject bootstrapObject = new GameObject("Sipoga Tactical Prototype Bootstrap");
+            bootstrapObject.AddComponent<TacticalPrototypeBootstrap>();
+        }
+
+        private void Awake()
+        {
+            Application.targetFrameRate = 120;
+            QualitySettings.vSyncCount = 0;
+            BuildPrototype();
+        }
+
+        private void BuildPrototype()
+        {
+            TacticalScenarioDefinition scenario = GlasshouseScenario.Create();
+            List<string> validationErrors = TacticalScenarioValidator.Validate(scenario);
+            for (int i = 0; i < validationErrors.Count; i++)
+            {
+                Debug.LogError("[Sipoga Tactics] " + validationErrors[i]);
+            }
+
+            TacticalPrototypeWorld world = TacticalPrototypeWorld.Build(scenario);
+
+            GameObject directorObject = new GameObject("Tactical Squad Director");
+            TacticalSquadDirector director = directorObject.AddComponent<TacticalSquadDirector>();
+            director.Initialize(scenario, world);
+
+            GameObject squadRoot = new GameObject("Six Operator Squad");
+            for (int i = 0; i < scenario.Units.Count; i++)
+            {
+                TacticalUnitPlan plan = scenario.Units[i];
+                GameObject unitObject = new GameObject(plan.Callsign);
+                unitObject.transform.SetParent(squadRoot.transform, false);
+                TacticalUnitAgent agent = unitObject.AddComponent<TacticalUnitAgent>();
+                agent.Initialize(director, plan, director.Engine.GetPosition(plan.HomePositionId));
+                director.RegisterAgent(agent);
+            }
+
+            GameObject cameraObject = new GameObject("Tactical Prototype Camera");
+            cameraObject.AddComponent<Camera>();
+            TacticalPrototypeCamera cameraController = cameraObject.AddComponent<TacticalPrototypeCamera>();
+            cameraController.Initialize();
+            director.SetCameraController(cameraController);
+
+            GameObject overlayObject = new GameObject("Tactical Dependency Overlay");
+            TacticalOverlayRenderer overlay = overlayObject.AddComponent<TacticalOverlayRenderer>();
+            overlay.Initialize(director);
+            TacticalThreatVisualizer threatVisualizer = overlayObject.AddComponent<TacticalThreatVisualizer>();
+            threatVisualizer.Initialize(director);
+
+            GameObject hudObject = new GameObject("Tactical Explanation HUD");
+            TacticalPrototypeHud hud = hudObject.AddComponent<TacticalPrototypeHud>();
+            hud.Initialize(director);
+            TacticalCommandHud commandHud = hudObject.AddComponent<TacticalCommandHud>();
+            commandHud.Initialize(director);
+
+            director.ResetCurrentPlaybook();
+            director.SelectUnit("alpha");
+        }
+    }
+}

--- a/Assets/Scripts/TacticalSquad/TacticalPrototypeBootstrap.cs.meta
+++ b/Assets/Scripts/TacticalSquad/TacticalPrototypeBootstrap.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2f237cfdb88a4e5dac3065102715f76f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/TacticalSquad/TacticalPrototypeCamera.cs
+++ b/Assets/Scripts/TacticalSquad/TacticalPrototypeCamera.cs
@@ -1,0 +1,175 @@
+using UnityEngine;
+
+namespace Sipoga.Tactics
+{
+    [RequireComponent(typeof(Camera))]
+    public sealed class TacticalPrototypeCamera : MonoBehaviour
+    {
+        private Camera _camera;
+        private TacticalUnitAgent _selectedAgent;
+        private bool _isTacticalView = true;
+        private float _tacticalZoom = 12.2f;
+
+        public bool IsTacticalView
+        {
+            get { return _isTacticalView; }
+        }
+
+        public Vector3 PlanarForward
+        {
+            get
+            {
+                Vector3 forward = transform.forward;
+                forward.y = 0f;
+                return forward.sqrMagnitude > 0.001f ? forward.normalized : Vector3.forward;
+            }
+        }
+
+        public Vector3 PlanarRight
+        {
+            get
+            {
+                Vector3 right = transform.right;
+                right.y = 0f;
+                return right.sqrMagnitude > 0.001f ? right.normalized : Vector3.right;
+            }
+        }
+
+        public void Initialize()
+        {
+            _camera = GetComponent<Camera>();
+            _camera.clearFlags = CameraClearFlags.SolidColor;
+            _camera.backgroundColor = new Color(0.018f, 0.024f, 0.030f);
+            _camera.allowHDR = true;
+            _camera.fieldOfView = 64f;
+            _camera.nearClipPlane = 0.05f;
+            _camera.farClipPlane = 120f;
+            TacticalPrototypeVisual.ConfigurePipelineCamera(gameObject);
+            _camera.orthographic = true;
+            _camera.orthographicSize = _tacticalZoom;
+            gameObject.tag = "MainCamera";
+
+            if (GetComponent<AudioListener>() == null)
+            {
+                gameObject.AddComponent<AudioListener>();
+            }
+
+            SnapToCurrentMode();
+        }
+
+        public void SetSelectedAgent(TacticalUnitAgent agent)
+        {
+            _selectedAgent = agent;
+        }
+
+        public void ToggleMode()
+        {
+            SetTacticalView(!_isTacticalView);
+        }
+
+        public void SetTacticalView(bool tacticalView)
+        {
+            _isTacticalView = tacticalView;
+            if (_camera != null)
+            {
+                _camera.orthographic = tacticalView;
+            }
+        }
+
+        private void Update()
+        {
+            if (_camera == null || !_isTacticalView)
+            {
+                return;
+            }
+
+            float scroll = Input.mouseScrollDelta.y;
+            if (Mathf.Abs(scroll) > 0.01f)
+            {
+                _tacticalZoom = Mathf.Clamp(_tacticalZoom - scroll * 0.8f, 8.5f, 17f);
+            }
+        }
+
+        private void LateUpdate()
+        {
+            if (_camera == null)
+            {
+                return;
+            }
+
+            if (_isTacticalView)
+            {
+                UpdateTacticalCamera();
+            }
+            else
+            {
+                UpdateOperatorCamera();
+            }
+        }
+
+        private void UpdateTacticalCamera()
+        {
+            Vector3 targetPosition = new Vector3(0f, 19.5f, -12.5f);
+            Quaternion targetRotation = Quaternion.LookRotation(
+                new Vector3(0f, 1.3f, 0.6f) - targetPosition,
+                Vector3.up);
+            float positionBlend = 1f - Mathf.Exp(-6.5f * Time.unscaledDeltaTime);
+            float rotationBlend = 1f - Mathf.Exp(-8f * Time.unscaledDeltaTime);
+            transform.position = Vector3.Lerp(transform.position, targetPosition, positionBlend);
+            transform.rotation = Quaternion.Slerp(transform.rotation, targetRotation, rotationBlend);
+            _camera.orthographic = true;
+            _camera.orthographicSize = Mathf.Lerp(
+                _camera.orthographicSize,
+                _tacticalZoom,
+                1f - Mathf.Exp(-9f * Time.unscaledDeltaTime));
+        }
+
+        private void UpdateOperatorCamera()
+        {
+            if (_selectedAgent == null)
+            {
+                return;
+            }
+
+            _camera.orthographic = false;
+            Vector3 forward = _selectedAgent.transform.forward;
+            forward.y = 0f;
+            if (forward.sqrMagnitude < 0.001f)
+            {
+                forward = Vector3.forward;
+            }
+
+            forward.Normalize();
+            Vector3 focus = _selectedAgent.transform.position + Vector3.up * 0.45f;
+            Vector3 targetPosition = focus - forward * 4.2f + Vector3.up * 2.7f;
+            Quaternion targetRotation = Quaternion.LookRotation(
+                focus + forward * 1.7f - targetPosition,
+                Vector3.up);
+            float positionBlend = 1f - Mathf.Exp(-10f * Time.unscaledDeltaTime);
+            float rotationBlend = 1f - Mathf.Exp(-12f * Time.unscaledDeltaTime);
+            transform.position = Vector3.Lerp(transform.position, targetPosition, positionBlend);
+            transform.rotation = Quaternion.Slerp(transform.rotation, targetRotation, rotationBlend);
+            _camera.fieldOfView = Mathf.Lerp(
+                _camera.fieldOfView,
+                68f,
+                1f - Mathf.Exp(-8f * Time.unscaledDeltaTime));
+        }
+
+        private void SnapToCurrentMode()
+        {
+            if (_isTacticalView)
+            {
+                transform.position = new Vector3(0f, 19.5f, -12.5f);
+                transform.rotation = Quaternion.LookRotation(
+                    new Vector3(0f, 1.3f, 0.6f) - transform.position,
+                    Vector3.up);
+            }
+            else if (_selectedAgent != null)
+            {
+                Vector3 focus = _selectedAgent.transform.position + Vector3.up * 0.45f;
+                transform.position = focus - _selectedAgent.transform.forward * 4.2f + Vector3.up * 2.7f;
+                transform.rotation = Quaternion.LookRotation(focus - transform.position, Vector3.up);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/TacticalSquad/TacticalPrototypeCamera.cs.meta
+++ b/Assets/Scripts/TacticalSquad/TacticalPrototypeCamera.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d7a88a1633284656abb6d2585b031abf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/TacticalSquad/TacticalPrototypeHud.cs
+++ b/Assets/Scripts/TacticalSquad/TacticalPrototypeHud.cs
@@ -1,0 +1,442 @@
+using UnityEngine;
+
+namespace Sipoga.Tactics
+{
+    public sealed class TacticalPrototypeHud : MonoBehaviour
+    {
+        private const float DesignWidth = 1600f;
+        private const float DesignHeight = 900f;
+
+        private TacticalSquadDirector _director;
+        private GUIStyle _topBar;
+        private GUIStyle _panel;
+        private GUIStyle _card;
+        private GUIStyle _selectedCard;
+        private GUIStyle _button;
+        private GUIStyle _buttonStrong;
+        private GUIStyle _title;
+        private GUIStyle _heading;
+        private GUIStyle _body;
+        private GUIStyle _small;
+        private GUIStyle _muted;
+        private GUIStyle _routeStatus;
+        private GUIStyle _afterAction;
+        private bool _stylesReady;
+
+        public void Initialize(TacticalSquadDirector director)
+        {
+            _director = director;
+        }
+
+        private void OnGUI()
+        {
+            if (_director == null || _director.Evaluation == null)
+            {
+                return;
+            }
+
+            EnsureStyles();
+            float scale = Mathf.Min(Screen.width / DesignWidth, Screen.height / DesignHeight);
+            if (scale <= 0f)
+            {
+                return;
+            }
+
+            Matrix4x4 previousMatrix = GUI.matrix;
+            GUI.matrix = Matrix4x4.TRS(
+                Vector3.zero,
+                Quaternion.identity,
+                new Vector3(scale, scale, 1f));
+
+            DrawTopBar();
+            DrawSquadPanel();
+            DrawRoutePanel();
+            DrawExplanationPanel();
+            DrawEventPanel();
+            DrawControls();
+            DrawPhaseCard();
+
+            GUI.matrix = previousMatrix;
+        }
+
+        private void DrawTopBar()
+        {
+            GUI.Box(new Rect(18f, 16f, 1564f, 62f), GUIContent.none, _topBar);
+            GUI.Label(new Rect(38f, 25f, 390f, 28f), "SIPOGA // TACTICAL PROTOTYPE", _title);
+            GUI.Label(
+                new Rect(38f, 50f, 520f, 20f),
+                _director.Scenario.DisplayName + "  •  " + _director.Scenario.Revision +
+                "  •  ORIGINAL TRAINING MAP",
+                _muted);
+
+            TacticalAttackPlaybook playbook = _director.CurrentPlaybook;
+            GUI.Label(new Rect(585f, 25f, 390f, 24f), playbook.Name, _heading);
+            GUI.Label(new Rect(585f, 49f, 390f, 20f), playbook.Summary, _small);
+
+            string phase = _director.Phase.ToString().ToUpperInvariant();
+            string timer = _director.Phase == TacticalPrototypePhase.Planning
+                ? "READY"
+                : _director.ExecutionTime.ToString("00.0") + "s";
+            GUI.Label(new Rect(1000f, 25f, 120f, 22f), phase, _heading);
+            GUI.Label(new Rect(1000f, 49f, 120f, 20f), timer, _muted);
+
+            string beginLabel = _director.Phase == TacticalPrototypePhase.Planning
+                ? "BEGIN"
+                : "RESTART";
+            if (GUI.Button(new Rect(1128f, 27f, 102f, 38f), beginLabel, _buttonStrong))
+            {
+                _director.StartOrRestartExecution();
+            }
+
+            if (GUI.Button(new Rect(1238f, 27f, 102f, 38f), "NEXT PLAY", _button))
+            {
+                _director.NextPlaybook();
+            }
+
+            if (GUI.Button(new Rect(1348f, 27f, 98f, 38f), "RESET", _button))
+            {
+                _director.ResetCurrentPlaybook();
+            }
+
+            string viewLabel = IsTacticalView() ? "OPERATOR" : "TACTICAL";
+            if (GUI.Button(new Rect(1454f, 27f, 108f, 38f), viewLabel, _button))
+            {
+                _director.ToggleView();
+            }
+        }
+
+        private void DrawSquadPanel()
+        {
+            GUI.Box(new Rect(18f, 92f, 352f, 598f), GUIContent.none, _panel);
+            GUI.Label(new Rect(36f, 108f, 260f, 26f), "SIX PROMISES", _heading);
+            GUI.Label(
+                new Rect(36f, 134f, 300f, 40f),
+                "Select an operator to see what they control and why their position works.",
+                _small);
+
+            for (int i = 0; i < _director.Scenario.Units.Count; i++)
+            {
+                TacticalUnitPlan plan = _director.Scenario.Units[i];
+                TacticalUnitAgent agent = _director.GetAgent(plan.UnitId);
+                TacticalUnitRuntimeState state = _director.Engine.GetUnitState(plan.UnitId);
+                bool selected = plan.UnitId == _director.SelectedUnitId;
+                Rect cardRect = new Rect(34f, 184f + i * 80f, 320f, 68f);
+                if (GUI.Button(cardRect, GUIContent.none, selected ? _selectedCard : _card))
+                {
+                    _director.SelectUnit(plan.UnitId);
+                }
+
+                Color previousColor = GUI.color;
+                GUI.color = plan.DisplayColor;
+                GUI.DrawTexture(
+                    new Rect(cardRect.x + 8f, cardRect.y + 10f, 5f, cardRect.height - 20f),
+                    Texture2D.whiteTexture);
+                GUI.color = previousColor;
+
+                GUI.Label(
+                    new Rect(cardRect.x + 22f, cardRect.y + 7f, 54f, 23f),
+                    (i + 1).ToString("00"),
+                    _muted);
+                GUI.Label(
+                    new Rect(cardRect.x + 65f, cardRect.y + 6f, 130f, 24f),
+                    plan.Callsign,
+                    _heading);
+
+                string condition = state.Condition == TacticalUnitCondition.Down
+                    ? "DOWN"
+                    : agent != null ? agent.GetStatusLabel() : "READY";
+                GUIStyle conditionStyle = new GUIStyle(_small);
+                conditionStyle.alignment = TextAnchor.UpperRight;
+                conditionStyle.normal.textColor = state.Condition == TacticalUnitCondition.Down
+                    ? new Color(1f, 0.35f, 0.38f)
+                    : plan.DisplayColor;
+                GUI.Label(
+                    new Rect(cardRect.x + 210f, cardRect.y + 8f, 92f, 22f),
+                    condition,
+                    conditionStyle);
+
+                GUI.Label(
+                    new Rect(cardRect.x + 65f, cardRect.y + 31f, 228f, 18f),
+                    _director.Engine.GetCurrentResponsibilityLabel(plan.UnitId, _director.Evaluation),
+                    _body);
+                GUI.Label(
+                    new Rect(cardRect.x + 65f, cardRect.y + 49f, 228f, 16f),
+                    _director.Engine.GetPositionLabel(plan.UnitId),
+                    _muted);
+            }
+        }
+
+        private void DrawRoutePanel()
+        {
+            GUI.Box(new Rect(1186f, 92f, 396f, 250f), GUIContent.none, _panel);
+            GUI.Label(new Rect(1204f, 108f, 270f, 26f), "LIVE MAP CONTROL", _heading);
+            GUI.Label(
+                new Rect(1204f, 134f, 345f, 34f),
+                "A route is safe only while enough independent promises remain active.",
+                _small);
+
+            for (int i = 0; i < _director.Evaluation.Routes.Count; i++)
+            {
+                TacticalRouteRuntimeState routeState = _director.Evaluation.Routes[i];
+                TacticalRouteDefinition route = _director.Engine.GetRouteDefinition(routeState.RouteId);
+                Rect routeRect = new Rect(1204f, 176f + i * 50f, 360f, 42f);
+                GUI.Box(routeRect, GUIContent.none, _card);
+
+                Color statusColor = GetRouteColor(routeState);
+                Color previousColor = GUI.color;
+                GUI.color = statusColor;
+                GUI.DrawTexture(
+                    new Rect(routeRect.x + 8f, routeRect.y + 8f, 4f, routeRect.height - 16f),
+                    Texture2D.whiteTexture);
+                GUI.color = previousColor;
+
+                GUI.Label(new Rect(routeRect.x + 20f, routeRect.y + 5f, 190f, 20f), route.Label, _body);
+                GUI.Label(
+                    new Rect(routeRect.x + 20f, routeRect.y + 23f, 200f, 16f),
+                    "pressure " + routeState.Pressure + "  •  baseline " + routeState.BaselineCoverage,
+                    _muted);
+
+                GUIStyle statusStyle = new GUIStyle(_routeStatus);
+                statusStyle.normal.textColor = statusColor;
+                GUI.Label(
+                    new Rect(routeRect.x + 215f, routeRect.y + 5f, 132f, 30f),
+                    routeState.Coverage + "/" + routeState.RequiredCoverage + "  " + routeState.StatusLabel,
+                    statusStyle);
+            }
+        }
+
+        private void DrawExplanationPanel()
+        {
+            GUI.Box(new Rect(1186f, 356f, 396f, 334f), GUIContent.none, _panel);
+            TacticalUnitPlan selectedPlan = _director.Engine.GetUnitPlan(_director.SelectedUnitId);
+            TacticalUnitRuntimeState selectedState = _director.Engine.GetUnitState(_director.SelectedUnitId);
+            TacticalExplanation explanation = _director.Engine.GetExplanation(
+                _director.SelectedUnitId,
+                _director.Evaluation);
+
+            GUI.Label(new Rect(1204f, 372f, 260f, 24f), selectedPlan.Callsign, _heading);
+            GUI.Label(
+                new Rect(1204f, 397f, 340f, 18f),
+                _director.Engine.GetCurrentResponsibilityLabel(selectedPlan.UnitId, _director.Evaluation) +
+                "  •  " + _director.Engine.GetPositionLabel(selectedPlan.UnitId),
+                _muted);
+
+            DrawExplanationRow(1204f, 426f, "WHAT", explanation.What, selectedPlan.DisplayColor);
+            DrawExplanationRow(1204f, 486f, "WHY SAFE", explanation.WhySafe, new Color(0.30f, 0.88f, 0.68f));
+            DrawExplanationRow(1204f, 554f, "WHAT BREAKS IT", explanation.WhatBreaksIt, new Color(1.0f, 0.42f, 0.42f));
+            DrawExplanationRow(1204f, 622f, "FALLBACK", explanation.Fallback, new Color(0.72f, 0.76f, 0.82f));
+
+            GUI.enabled = selectedState.Condition != TacticalUnitCondition.Down;
+            if (GUI.Button(new Rect(1204f, 657f, 104f, 24f), "FALL BACK", _button))
+            {
+                _director.OrderSelectedFallback();
+            }
+
+            if (GUI.Button(new Rect(1314f, 657f, 104f, 24f), "HOLD ROLE", _button))
+            {
+                _director.OrderSelectedToAssignment();
+            }
+            GUI.enabled = true;
+
+            string downLabel = selectedState.Condition == TacticalUnitCondition.Down ? "RESTORE" : "TEST DOWN";
+            if (GUI.Button(new Rect(1424f, 657f, 140f, 24f), downLabel, _button))
+            {
+                _director.ToggleSelectedDown();
+            }
+        }
+
+        private void DrawEventPanel()
+        {
+            GUI.Box(new Rect(386f, 696f, 784f, 142f), GUIContent.none, _panel);
+            GUI.Label(new Rect(404f, 710f, 260f, 24f), "CAUSAL REPLAY", _heading);
+            GUI.Label(
+                new Rect(404f, 733f, 720f, 18f),
+                "The log names the dependency that changed, not only the kill or breach that happened.",
+                _muted);
+
+            int first = Mathf.Max(0, _director.Events.Count - 4);
+            float y = 758f;
+            for (int i = first; i < _director.Events.Count; i++)
+            {
+                TacticalEventRecord record = _director.Events[i];
+                GUI.Label(
+                    new Rect(404f, y, 64f, 19f),
+                    record.Time.ToString("00.0"),
+                    _muted);
+                GUI.Label(new Rect(466f, y, 680f, 19f), record.Text, _small);
+                y += 20f;
+            }
+        }
+
+        private void DrawControls()
+        {
+            GUI.Box(new Rect(18f, 704f, 352f, 178f), GUIContent.none, _panel);
+            GUI.Label(new Rect(36f, 720f, 200f, 24f), "CONTROLS", _heading);
+            GUI.Label(
+                new Rect(36f, 749f, 316f, 114f),
+                "1–6  select operator\n" +
+                "Tab  tactical / operator view\n" +
+                "WASD  move selected operator\n" +
+                "F / H  fallback / return to role\n" +
+                "X  test operator down\n" +
+                "B  cycle permeable screen\n" +
+                "P or [ ]  change attacker play\n" +
+                "G  squad collapse go-code",
+                _body);
+
+            GUI.Box(new Rect(1186f, 704f, 396f, 178f), GUIContent.none, _panel);
+            GUI.Label(new Rect(1204f, 720f, 250f, 24f), "SURFACE + GO-CODE", _heading);
+            TacticalSurfaceState screenState = _director.Engine.GetSurfaceState(
+                GlasshouseScenario.PermeableScreenId);
+            GUI.Label(
+                new Rect(1204f, 750f, 350f, 20f),
+                "Overwatch screen: " + screenState.ToString().ToUpperInvariant(),
+                _body);
+            if (GUI.Button(new Rect(1204f, 782f, 170f, 36f), "CYCLE SCREEN [B]", _button))
+            {
+                _director.CyclePermeableScreen();
+            }
+
+            if (GUI.Button(new Rect(1382f, 782f, 182f, 36f), "COLLAPSE [G]", _buttonStrong))
+            {
+                _director.TriggerGoCode();
+            }
+
+            GUI.Label(
+                new Rect(1204f, 828f, 350f, 42f),
+                "Permeable transmits Bravo's line. Sealed deletes it. Open preserves it.",
+                _small);
+        }
+
+        private void DrawPhaseCard()
+        {
+            if (_director.Phase == TacticalPrototypePhase.Execution)
+            {
+                return;
+            }
+
+            Rect cardRect = new Rect(430f, 96f, 690f, 82f);
+            GUI.Box(cardRect, GUIContent.none, _topBar);
+            if (_director.Phase == TacticalPrototypePhase.Planning)
+            {
+                GUI.Label(new Rect(452f, 110f, 620f, 24f), "READ THE PLAN BEFORE THE FIGHT", _heading);
+                GUI.Label(
+                    new Rect(452f, 137f, 630f, 30f),
+                    "Green routes are not inherently safe. They are safe because named operators are keeping interlocking promises.",
+                    _body);
+            }
+            else
+            {
+                GUI.Label(new Rect(452f, 108f, 620f, 24f), "AFTER ACTION", _heading);
+                GUI.Label(
+                    new Rect(452f, 135f, 630f, 34f),
+                    _director.CurrentPlaybook.Lesson,
+                    _afterAction);
+            }
+        }
+
+        private void DrawExplanationRow(float x, float y, string label, string text, Color color)
+        {
+            GUIStyle labelStyle = new GUIStyle(_small);
+            labelStyle.normal.textColor = color;
+            GUI.Label(new Rect(x, y, 120f, 18f), label, labelStyle);
+            GUI.Label(new Rect(x, y + 18f, 350f, 45f), text, _small);
+        }
+
+        private bool IsTacticalView()
+        {
+            Camera main = Camera.main;
+            if (main == null)
+            {
+                return true;
+            }
+
+            TacticalPrototypeCamera controller = main.GetComponent<TacticalPrototypeCamera>();
+            return controller == null || controller.IsTacticalView;
+        }
+
+        private Color GetRouteColor(TacticalRouteRuntimeState state)
+        {
+            if (state.IsSecured)
+            {
+                return state.IsFlexHolding
+                    ? new Color(0.98f, 0.88f, 0.28f)
+                    : new Color(0.24f, 0.92f, 0.67f);
+            }
+
+            return state.IsBeingRepaired
+                ? new Color(1.00f, 0.58f, 0.20f)
+                : new Color(1.00f, 0.22f, 0.30f);
+        }
+
+        private void EnsureStyles()
+        {
+            if (_stylesReady)
+            {
+                return;
+            }
+
+            _topBar = MakeBoxStyle(new Color(0.035f, 0.045f, 0.055f, 0.96f), 10);
+            _panel = MakeBoxStyle(new Color(0.030f, 0.039f, 0.047f, 0.93f), 8);
+            _card = MakeBoxStyle(new Color(0.060f, 0.073f, 0.084f, 0.92f), 5);
+            _selectedCard = MakeBoxStyle(new Color(0.105f, 0.128f, 0.145f, 0.98f), 5);
+
+            _button = new GUIStyle(GUI.skin.button);
+            _button.normal.background = MakeTexture(new Color(0.10f, 0.12f, 0.14f, 0.98f));
+            _button.hover.background = MakeTexture(new Color(0.15f, 0.18f, 0.21f, 1f));
+            _button.active.background = MakeTexture(new Color(0.07f, 0.09f, 0.11f, 1f));
+            _button.normal.textColor = new Color(0.82f, 0.86f, 0.89f);
+            _button.hover.textColor = Color.white;
+            _button.fontSize = 12;
+            _button.fontStyle = FontStyle.Bold;
+
+            _buttonStrong = new GUIStyle(_button);
+            _buttonStrong.normal.background = MakeTexture(new Color(0.18f, 0.50f, 0.47f, 0.98f));
+            _buttonStrong.hover.background = MakeTexture(new Color(0.23f, 0.64f, 0.59f, 1f));
+            _buttonStrong.normal.textColor = Color.white;
+
+            _title = MakeTextStyle(20, FontStyle.Bold, new Color(0.96f, 0.98f, 1f), TextAnchor.UpperLeft, false);
+            _heading = MakeTextStyle(15, FontStyle.Bold, new Color(0.93f, 0.96f, 0.98f), TextAnchor.UpperLeft, false);
+            _body = MakeTextStyle(13, FontStyle.Normal, new Color(0.82f, 0.86f, 0.89f), TextAnchor.UpperLeft, true);
+            _small = MakeTextStyle(12, FontStyle.Normal, new Color(0.78f, 0.82f, 0.85f), TextAnchor.UpperLeft, true);
+            _muted = MakeTextStyle(11, FontStyle.Normal, new Color(0.47f, 0.54f, 0.59f), TextAnchor.UpperLeft, true);
+            _routeStatus = MakeTextStyle(13, FontStyle.Bold, Color.white, TextAnchor.MiddleRight, false);
+            _afterAction = MakeTextStyle(13, FontStyle.Bold, new Color(0.98f, 0.87f, 0.36f), TextAnchor.UpperLeft, true);
+            _stylesReady = true;
+        }
+
+        private GUIStyle MakeBoxStyle(Color color, int padding)
+        {
+            GUIStyle style = new GUIStyle(GUI.skin.box);
+            style.normal.background = MakeTexture(color);
+            style.padding = new RectOffset(padding, padding, padding, padding);
+            return style;
+        }
+
+        private GUIStyle MakeTextStyle(
+            int fontSize,
+            FontStyle fontStyle,
+            Color color,
+            TextAnchor alignment,
+            bool wordWrap)
+        {
+            GUIStyle style = new GUIStyle(GUI.skin.label);
+            style.fontSize = fontSize;
+            style.fontStyle = fontStyle;
+            style.normal.textColor = color;
+            style.alignment = alignment;
+            style.wordWrap = wordWrap;
+            style.clipping = TextClipping.Clip;
+            return style;
+        }
+
+        private Texture2D MakeTexture(Color color)
+        {
+            Texture2D texture = new Texture2D(1, 1, TextureFormat.RGBA32, false);
+            texture.SetPixel(0, 0, color);
+            texture.Apply();
+            texture.hideFlags = HideFlags.HideAndDontSave;
+            return texture;
+        }
+    }
+}

--- a/Assets/Scripts/TacticalSquad/TacticalPrototypeHud.cs.meta
+++ b/Assets/Scripts/TacticalSquad/TacticalPrototypeHud.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 539b90b91c0b48d1925a3c6466608e73
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/TacticalSquad/TacticalPrototypeVisual.cs
+++ b/Assets/Scripts/TacticalSquad/TacticalPrototypeVisual.cs
@@ -1,0 +1,285 @@
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Rendering;
+
+namespace Sipoga.Tactics
+{
+    public static class TacticalPrototypeVisual
+    {
+        private static readonly Dictionary<string, Material> Materials =
+            new Dictionary<string, Material>();
+
+        public static Material GetMaterial(Color color, bool unlit)
+        {
+            string key = ColorUtility.ToHtmlStringRGBA(color) + (unlit ? "-unlit" : "-lit");
+            Material existing;
+            if (Materials.TryGetValue(key, out existing) && existing != null)
+            {
+                return existing;
+            }
+
+            Shader shader = FindCompatibleShader(unlit);
+            if (shader == null)
+            {
+                shader = Shader.Find("Hidden/InternalErrorShader");
+            }
+
+            Material material = new Material(shader);
+            material.name = "Runtime Tactical Material " + key;
+            if (material.HasProperty("_BaseColor"))
+            {
+                material.SetColor("_BaseColor", color);
+            }
+
+            if (material.HasProperty("_UnlitColor"))
+            {
+                material.SetColor("_UnlitColor", color);
+            }
+
+            if (material.HasProperty("_Color"))
+            {
+                material.SetColor("_Color", color);
+            }
+
+            if (material.HasProperty("_EmissiveColor"))
+            {
+                material.SetColor("_EmissiveColor", color * 0.12f);
+            }
+
+            Materials[key] = material;
+            return material;
+        }
+
+        public static void ConfigurePipelineCamera(GameObject cameraObject)
+        {
+            string pipelineName = GetActivePipelineName();
+            if (pipelineName.IndexOf("HDRenderPipeline", System.StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                TryAddLoadedComponent(
+                    cameraObject,
+                    "UnityEngine.Rendering.HighDefinition.HDAdditionalCameraData");
+            }
+            else if (pipelineName.IndexOf("Universal", System.StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                TryAddLoadedComponent(
+                    cameraObject,
+                    "UnityEngine.Rendering.Universal.UniversalAdditionalCameraData");
+            }
+        }
+
+        public static void ConfigurePipelineLight(GameObject lightObject)
+        {
+            string pipelineName = GetActivePipelineName();
+            if (pipelineName.IndexOf("HDRenderPipeline", System.StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                TryAddLoadedComponent(
+                    lightObject,
+                    "UnityEngine.Rendering.HighDefinition.HDAdditionalLightData");
+            }
+            else if (pipelineName.IndexOf("Universal", System.StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                TryAddLoadedComponent(
+                    lightObject,
+                    "UnityEngine.Rendering.Universal.UniversalAdditionalLightData");
+            }
+        }
+
+        private static string GetActivePipelineName()
+        {
+            RenderPipelineAsset pipeline = GraphicsSettings.currentRenderPipeline;
+            return pipeline != null ? pipeline.GetType().Name : string.Empty;
+        }
+
+        private static void TryAddLoadedComponent(GameObject target, string fullTypeName)
+        {
+            if (target == null)
+            {
+                return;
+            }
+
+            System.Reflection.Assembly[] assemblies = System.AppDomain.CurrentDomain.GetAssemblies();
+            for (int i = 0; i < assemblies.Length; i++)
+            {
+                System.Type type = assemblies[i].GetType(fullTypeName, false);
+                if (type == null || !typeof(Component).IsAssignableFrom(type))
+                {
+                    continue;
+                }
+
+                if (target.GetComponent(type) == null)
+                {
+                    target.AddComponent(type);
+                }
+
+                return;
+            }
+        }
+
+        private static Shader FindCompatibleShader(bool unlit)
+        {
+            RenderPipelineAsset pipeline = GraphicsSettings.currentRenderPipeline;
+            string pipelineName = pipeline != null ? pipeline.GetType().Name : string.Empty;
+
+            if (pipelineName.IndexOf("HDRenderPipeline", System.StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                Shader hdrp = Shader.Find(unlit ? "HDRP/Unlit" : "HDRP/Lit");
+                if (hdrp != null)
+                {
+                    return hdrp;
+                }
+            }
+
+            if (pipelineName.IndexOf("Universal", System.StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                Shader urp = Shader.Find(
+                    unlit ? "Universal Render Pipeline/Unlit" : "Universal Render Pipeline/Lit");
+                if (urp != null)
+                {
+                    return urp;
+                }
+            }
+
+            string[] fallbackNames = unlit
+                ? new[]
+                {
+                    "HDRP/Unlit",
+                    "Universal Render Pipeline/Unlit",
+                    "Unlit/Color",
+                    "Sprites/Default"
+                }
+                : new[]
+                {
+                    "HDRP/Lit",
+                    "Universal Render Pipeline/Lit",
+                    "Standard",
+                    "Unlit/Color"
+                };
+
+            for (int i = 0; i < fallbackNames.Length; i++)
+            {
+                Shader candidate = Shader.Find(fallbackNames[i]);
+                if (candidate != null)
+                {
+                    return candidate;
+                }
+            }
+
+            return null;
+        }
+
+        public static GameObject CreateBlock(
+            string name,
+            Vector3 position,
+            Vector3 scale,
+            Color color,
+            Transform parent,
+            bool collider)
+        {
+            GameObject block = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            block.name = name;
+            block.transform.SetParent(parent, false);
+            block.transform.position = position;
+            block.transform.localScale = scale;
+            Renderer renderer = block.GetComponent<Renderer>();
+            renderer.sharedMaterial = GetMaterial(color, true);
+
+            if (!collider)
+            {
+                Collider blockCollider = block.GetComponent<Collider>();
+                if (blockCollider != null)
+                {
+                    Object.Destroy(blockCollider);
+                }
+            }
+
+            return block;
+        }
+
+        public static GameObject CreateCylinder(
+            string name,
+            Vector3 position,
+            Vector3 scale,
+            Color color,
+            Transform parent,
+            bool collider)
+        {
+            GameObject cylinder = GameObject.CreatePrimitive(PrimitiveType.Cylinder);
+            cylinder.name = name;
+            cylinder.transform.SetParent(parent, false);
+            cylinder.transform.position = position;
+            cylinder.transform.localScale = scale;
+            Renderer renderer = cylinder.GetComponent<Renderer>();
+            renderer.sharedMaterial = GetMaterial(color, true);
+
+            if (!collider)
+            {
+                Collider cylinderCollider = cylinder.GetComponent<Collider>();
+                if (cylinderCollider != null)
+                {
+                    Object.Destroy(cylinderCollider);
+                }
+            }
+
+            return cylinder;
+        }
+
+        public static TextMesh CreateWorldLabel(
+            string text,
+            Vector3 position,
+            float characterSize,
+            Color color,
+            Transform parent)
+        {
+            GameObject labelObject = new GameObject("Label " + text);
+            labelObject.transform.SetParent(parent, false);
+            labelObject.transform.position = position;
+            TextMesh textMesh = labelObject.AddComponent<TextMesh>();
+            textMesh.text = text;
+            textMesh.anchor = TextAnchor.MiddleCenter;
+            textMesh.alignment = TextAlignment.Center;
+            textMesh.fontSize = 64;
+            textMesh.characterSize = characterSize;
+            textMesh.color = color;
+            textMesh.fontStyle = FontStyle.Bold;
+            labelObject.AddComponent<TacticalBillboard>();
+            return textMesh;
+        }
+
+        public static LineRenderer CreateLine(
+            string name,
+            float width,
+            Color color,
+            Transform parent)
+        {
+            GameObject lineObject = new GameObject(name);
+            lineObject.transform.SetParent(parent, false);
+            LineRenderer line = lineObject.AddComponent<LineRenderer>();
+            line.positionCount = 2;
+            line.useWorldSpace = true;
+            line.startWidth = width;
+            line.endWidth = width;
+            line.numCapVertices = 4;
+            line.numCornerVertices = 2;
+            line.sharedMaterial = GetMaterial(color, true);
+            line.startColor = color;
+            line.endColor = color;
+            line.shadowCastingMode = UnityEngine.Rendering.ShadowCastingMode.Off;
+            line.receiveShadows = false;
+            return line;
+        }
+    }
+
+    public sealed class TacticalBillboard : MonoBehaviour
+    {
+        private void LateUpdate()
+        {
+            Camera camera = Camera.main;
+            if (camera == null)
+            {
+                return;
+            }
+
+            transform.rotation = camera.transform.rotation;
+        }
+    }
+}

--- a/Assets/Scripts/TacticalSquad/TacticalPrototypeVisual.cs.meta
+++ b/Assets/Scripts/TacticalSquad/TacticalPrototypeVisual.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 05640be3908e48358bb4a1b1e644c1d5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/TacticalSquad/TacticalPrototypeWorld.cs
+++ b/Assets/Scripts/TacticalSquad/TacticalPrototypeWorld.cs
@@ -1,0 +1,297 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Sipoga.Tactics
+{
+    public sealed class TacticalPrototypeWorld : MonoBehaviour
+    {
+        private sealed class SurfaceVisual
+        {
+            public GameObject SolidPanel;
+            public readonly List<GameObject> Slats = new List<GameObject>();
+        }
+
+        private readonly Dictionary<string, SurfaceVisual> _surfaceVisuals =
+            new Dictionary<string, SurfaceVisual>();
+
+        public static TacticalPrototypeWorld Build(TacticalScenarioDefinition scenario)
+        {
+            GameObject root = new GameObject("Glasshouse Tactical Environment");
+            TacticalPrototypeWorld world = root.AddComponent<TacticalPrototypeWorld>();
+            world.BuildEnvironment(scenario);
+            return world;
+        }
+
+        public void UpdateSurface(string surfaceId, TacticalSurfaceState state)
+        {
+            SurfaceVisual visual;
+            if (!_surfaceVisuals.TryGetValue(surfaceId, out visual))
+            {
+                return;
+            }
+
+            bool showPanel = state == TacticalSurfaceState.Sealed;
+            bool showSlats = state == TacticalSurfaceState.Permeable;
+            visual.SolidPanel.SetActive(showPanel);
+            for (int i = 0; i < visual.Slats.Count; i++)
+            {
+                visual.Slats[i].SetActive(showSlats);
+            }
+        }
+
+        private void BuildEnvironment(TacticalScenarioDefinition scenario)
+        {
+            RenderSettings.ambientMode = UnityEngine.Rendering.AmbientMode.Trilight;
+            RenderSettings.ambientSkyColor = new Color(0.18f, 0.22f, 0.27f);
+            RenderSettings.ambientEquatorColor = new Color(0.08f, 0.10f, 0.13f);
+            RenderSettings.ambientGroundColor = new Color(0.025f, 0.03f, 0.04f);
+            RenderSettings.fog = true;
+            RenderSettings.fogColor = new Color(0.035f, 0.045f, 0.055f);
+            RenderSettings.fogMode = FogMode.Linear;
+            RenderSettings.fogStartDistance = 26f;
+            RenderSettings.fogEndDistance = 60f;
+
+            Color slab = new Color(0.055f, 0.065f, 0.078f);
+            Color roomA = new Color(0.11f, 0.14f, 0.16f);
+            Color roomB = new Color(0.13f, 0.12f, 0.15f);
+            Color roomC = new Color(0.09f, 0.15f, 0.15f);
+            Color wall = new Color(0.20f, 0.23f, 0.26f);
+            Color wallEdge = new Color(0.34f, 0.37f, 0.40f);
+            Color platform = new Color(0.14f, 0.16f, 0.19f);
+            Color railing = new Color(0.38f, 0.42f, 0.46f);
+            Color cover = new Color(0.24f, 0.27f, 0.30f);
+
+            TacticalPrototypeVisual.CreateBlock(
+                "Foundation",
+                new Vector3(0f, -0.2f, 0.7f),
+                new Vector3(21.5f, 0.35f, 15.8f),
+                slab,
+                transform,
+                true);
+
+            CreateRoomFloor("Archive floor", new Vector3(-5.4f, 0.0f, -3.3f), new Vector3(8.0f, 0.10f, 5.8f), roomA);
+            CreateRoomFloor("Packing floor", new Vector3(3.4f, 0.0f, -3.3f), new Vector3(8.0f, 0.10f, 5.8f), roomB);
+            CreateRoomFloor("Service floor", new Vector3(-0.3f, 0.01f, 2.6f), new Vector3(5.1f, 0.11f, 5.7f), roomC);
+            CreateRoomFloor("Cold floor", new Vector3(-6.0f, 0.01f, 3.3f), new Vector3(5.5f, 0.11f, 5.4f), roomA);
+            CreateRoomFloor("Crimson floor", new Vector3(6.2f, 0.01f, 3.4f), new Vector3(5.1f, 0.11f, 5.3f), roomB);
+
+            // Outer shell. Door-sized gaps make the topology legible from the tactical camera.
+            CreateWall("North west shell", new Vector3(-6.4f, 1.15f, 8.15f), new Vector3(7.5f, 2.3f, 0.22f), wall);
+            CreateWall("North east shell", new Vector3(6.5f, 1.15f, 8.15f), new Vector3(7.2f, 2.3f, 0.22f), wall);
+            CreateWall("West shell", new Vector3(-10.65f, 1.15f, 0.8f), new Vector3(0.22f, 2.3f, 14.7f), wall);
+            CreateWall("East shell", new Vector3(10.65f, 1.15f, 0.8f), new Vector3(0.22f, 2.3f, 14.7f), wall);
+            CreateWall("South west shell", new Vector3(-6.3f, 1.15f, -6.55f), new Vector3(7.7f, 2.3f, 0.22f), wall);
+            CreateWall("South east shell", new Vector3(6.2f, 1.15f, -6.55f), new Vector3(7.9f, 2.3f, 0.22f), wall);
+
+            // Interior partitions and thresholds.
+            CreateWall("Archive Packing divider south", new Vector3(-1.15f, 1.05f, -4.6f), new Vector3(0.20f, 2.1f, 3.7f), wallEdge);
+            CreateWall("Archive Packing divider north", new Vector3(-1.15f, 1.05f, -1.0f), new Vector3(0.20f, 2.1f, 1.2f), wallEdge);
+            CreateWall("Archive north partition", new Vector3(-6.2f, 1.05f, -0.35f), new Vector3(6.9f, 2.1f, 0.20f), wall);
+            CreateWall("Packing north partition", new Vector3(4.2f, 1.05f, -0.35f), new Vector3(5.6f, 2.1f, 0.20f), wall);
+            CreateWall("Cold Service divider", new Vector3(-3.15f, 1.05f, 3.1f), new Vector3(0.20f, 2.1f, 5.2f), wallEdge);
+            CreateWall("Service Crimson divider", new Vector3(2.55f, 1.05f, 4.6f), new Vector3(0.20f, 2.1f, 2.3f), wallEdge);
+
+            // Tactical cover that makes the important positions readable.
+            TacticalPrototypeVisual.CreateBlock("Archive shelves", new Vector3(-6.5f, 0.75f, -2.0f), new Vector3(2.4f, 1.5f, 0.75f), cover, transform, true);
+            TacticalPrototypeVisual.CreateBlock("Packing machinery", new Vector3(3.7f, 0.65f, -2.8f), new Vector3(2.0f, 1.3f, 1.3f), cover, transform, true);
+            TacticalPrototypeVisual.CreateBlock("Service desk", new Vector3(-0.4f, 0.55f, 1.4f), new Vector3(2.0f, 1.1f, 0.75f), cover, transform, true);
+            TacticalPrototypeVisual.CreateBlock("Cold pallets", new Vector3(-6.7f, 0.55f, 4.0f), new Vector3(1.8f, 1.1f, 1.7f), cover, transform, true);
+            TacticalPrototypeVisual.CreateBlock("Crimson cover", new Vector3(5.5f, 0.65f, 2.1f), new Vector3(1.8f, 1.3f, 0.8f), cover, transform, true);
+
+            BuildUpperFloor(platform, railing);
+            BuildStaircase(platform, wallEdge);
+            BuildObjectives();
+            BuildSurfaceVisuals(scenario);
+            BuildLabels();
+            BuildLighting();
+        }
+
+        private void BuildUpperFloor(Color platform, Color railing)
+        {
+            TacticalPrototypeVisual.CreateBlock(
+                "Overwatch catwalk",
+                new Vector3(-5.2f, 3.18f, 0.4f),
+                new Vector3(7.3f, 0.30f, 6.2f),
+                platform,
+                transform,
+                true);
+            TacticalPrototypeVisual.CreateBlock(
+                "Gallery catwalk",
+                new Vector3(4.6f, 3.18f, -1.5f),
+                new Vector3(7.2f, 0.30f, 5.2f),
+                platform,
+                transform,
+                true);
+            TacticalPrototypeVisual.CreateBlock(
+                "Upper bridge",
+                new Vector3(-0.1f, 3.18f, -1.7f),
+                new Vector3(3.1f, 0.30f, 1.35f),
+                platform,
+                transform,
+                true);
+
+            // Rails are low enough that every dependency remains visible in the map view.
+            TacticalPrototypeVisual.CreateBlock("Overwatch rail north", new Vector3(-5.2f, 3.75f, 3.45f), new Vector3(7.3f, 1.0f, 0.12f), railing, transform, false);
+            TacticalPrototypeVisual.CreateBlock("Overwatch rail west", new Vector3(-8.8f, 3.75f, 0.4f), new Vector3(0.12f, 1.0f, 6.2f), railing, transform, false);
+            TacticalPrototypeVisual.CreateBlock("Gallery rail east", new Vector3(8.15f, 3.75f, -1.5f), new Vector3(0.12f, 1.0f, 5.2f), railing, transform, false);
+            TacticalPrototypeVisual.CreateBlock("Gallery rail south", new Vector3(4.6f, 3.75f, -4.05f), new Vector3(7.2f, 1.0f, 0.12f), railing, transform, false);
+
+            // Hatch marker on the catwalk and a projected target below it.
+            TacticalPrototypeVisual.CreateBlock(
+                "Cold hatch opening",
+                new Vector3(-5.2f, 3.36f, 2.75f),
+                new Vector3(1.6f, 0.06f, 1.6f),
+                new Color(0.02f, 0.025f, 0.03f),
+                transform,
+                false);
+            TacticalPrototypeVisual.CreateBlock(
+                "Cold hatch rim north",
+                new Vector3(-5.2f, 3.40f, 3.57f),
+                new Vector3(1.9f, 0.12f, 0.12f),
+                new Color(0.65f, 0.75f, 0.80f),
+                transform,
+                false);
+            TacticalPrototypeVisual.CreateBlock(
+                "Cold hatch rim south",
+                new Vector3(-5.2f, 3.40f, 1.93f),
+                new Vector3(1.9f, 0.12f, 0.12f),
+                new Color(0.65f, 0.75f, 0.80f),
+                transform,
+                false);
+        }
+
+        private void BuildStaircase(Color platform, Color edge)
+        {
+            const int stepCount = 11;
+            for (int i = 0; i < stepCount; i++)
+            {
+                float t = i / (float)(stepCount - 1);
+                float y = 0.12f + t * 3.02f;
+                float z = 6.7f - t * 4.7f;
+                TacticalPrototypeVisual.CreateBlock(
+                    "Crimson stair " + i,
+                    new Vector3(7.2f, y, z),
+                    new Vector3(2.2f, 0.24f, 0.55f),
+                    i % 2 == 0 ? platform : edge,
+                    transform,
+                    true);
+            }
+        }
+
+        private void BuildObjectives()
+        {
+            Color objectiveA = new Color(0.25f, 0.82f, 0.95f);
+            Color objectiveB = new Color(0.93f, 0.42f, 0.66f);
+            TacticalPrototypeVisual.CreateCylinder(
+                "Objective A",
+                new Vector3(-4.1f, 0.18f, -4.2f),
+                new Vector3(0.8f, 0.12f, 0.8f),
+                objectiveA,
+                transform,
+                false);
+            TacticalPrototypeVisual.CreateCylinder(
+                "Objective B",
+                new Vector3(2.4f, 0.18f, -4.2f),
+                new Vector3(0.8f, 0.12f, 0.8f),
+                objectiveB,
+                transform,
+                false);
+            TacticalPrototypeVisual.CreateWorldLabel("A", new Vector3(-4.1f, 0.65f, -4.2f), 0.14f, objectiveA, transform);
+            TacticalPrototypeVisual.CreateWorldLabel("B", new Vector3(2.4f, 0.65f, -4.2f), 0.14f, objectiveB, transform);
+        }
+
+        private void BuildSurfaceVisuals(TacticalScenarioDefinition scenario)
+        {
+            for (int surfaceIndex = 0; surfaceIndex < scenario.Surfaces.Count; surfaceIndex++)
+            {
+                TacticalSurfaceDefinition surface = scenario.Surfaces[surfaceIndex];
+                GameObject parent = new GameObject(surface.Label);
+                parent.transform.SetParent(transform, false);
+                parent.transform.position = surface.WorldPosition;
+
+                SurfaceVisual visual = new SurfaceVisual();
+                visual.SolidPanel = TacticalPrototypeVisual.CreateBlock(
+                    "Sealed panel",
+                    surface.WorldPosition,
+                    surface.WorldScale,
+                    new Color(0.88f, 0.30f, 0.32f),
+                    parent.transform,
+                    false);
+                // CreateBlock uses world coordinates, so restore parenting without preserving a duplicate offset.
+                visual.SolidPanel.transform.SetParent(parent.transform, true);
+
+                const int slatCount = 8;
+                for (int i = 0; i < slatCount; i++)
+                {
+                    float t = slatCount == 1 ? 0.5f : i / (float)(slatCount - 1);
+                    float localZ = Mathf.Lerp(-surface.WorldScale.z * 0.46f, surface.WorldScale.z * 0.46f, t);
+                    GameObject slat = TacticalPrototypeVisual.CreateBlock(
+                        "Permeable slat " + i,
+                        surface.WorldPosition + new Vector3(0f, 0f, localZ),
+                        new Vector3(surface.WorldScale.x, surface.WorldScale.y, 0.18f),
+                        new Color(0.28f, 0.82f, 0.82f),
+                        parent.transform,
+                        false);
+                    slat.transform.SetParent(parent.transform, true);
+                    visual.Slats.Add(slat);
+                }
+
+                _surfaceVisuals[surface.Id] = visual;
+                UpdateSurface(surface.Id, surface.DefaultState);
+            }
+        }
+
+        private void BuildLabels()
+        {
+            Color label = new Color(0.70f, 0.76f, 0.80f);
+            TacticalPrototypeVisual.CreateWorldLabel("ARCHIVE", new Vector3(-5.4f, 0.45f, -5.0f), 0.085f, label, transform);
+            TacticalPrototypeVisual.CreateWorldLabel("PACKING", new Vector3(3.5f, 0.45f, -5.0f), 0.085f, label, transform);
+            TacticalPrototypeVisual.CreateWorldLabel("SERVICE", new Vector3(-0.3f, 0.45f, 4.6f), 0.075f, label, transform);
+            TacticalPrototypeVisual.CreateWorldLabel("COLD STORE", new Vector3(-6.0f, 0.45f, 6.0f), 0.075f, label, transform);
+            TacticalPrototypeVisual.CreateWorldLabel("CRIMSON", new Vector3(6.2f, 0.45f, 6.2f), 0.075f, new Color(1.0f, 0.42f, 0.48f), transform);
+            TacticalPrototypeVisual.CreateWorldLabel("OVERWATCH", new Vector3(-6.2f, 4.0f, -1.5f), 0.075f, label, transform);
+            TacticalPrototypeVisual.CreateWorldLabel("GALLERY", new Vector3(5.3f, 4.0f, -3.2f), 0.075f, label, transform);
+        }
+
+        private void BuildLighting()
+        {
+            GameObject sunObject = new GameObject("Tactical key light");
+            sunObject.transform.SetParent(transform, false);
+            Light sun = sunObject.AddComponent<Light>();
+            TacticalPrototypeVisual.ConfigurePipelineLight(sunObject);
+            sun.type = LightType.Directional;
+            sun.color = new Color(0.86f, 0.93f, 1.0f);
+            sun.intensity = 1.15f;
+            sun.shadows = LightShadows.Soft;
+            sunObject.transform.rotation = Quaternion.Euler(52f, -38f, 0f);
+
+            CreatePointLight("Archive light", new Vector3(-5f, 5.8f, -2.5f), new Color(0.32f, 0.70f, 1.0f), 6f, 18f);
+            CreatePointLight("Packing light", new Vector3(4f, 5.8f, -2.0f), new Color(1.0f, 0.55f, 0.35f), 5f, 17f);
+            CreatePointLight("Service light", new Vector3(0f, 4.8f, 4.3f), new Color(0.35f, 1.0f, 0.80f), 4f, 15f);
+        }
+
+        private void CreatePointLight(string name, Vector3 position, Color color, float intensity, float range)
+        {
+            GameObject lightObject = new GameObject(name);
+            lightObject.transform.SetParent(transform, false);
+            lightObject.transform.position = position;
+            Light light = lightObject.AddComponent<Light>();
+            TacticalPrototypeVisual.ConfigurePipelineLight(lightObject);
+            light.type = LightType.Point;
+            light.color = color;
+            light.intensity = intensity;
+            light.range = range;
+            light.shadows = LightShadows.None;
+        }
+
+        private void CreateRoomFloor(string name, Vector3 position, Vector3 scale, Color color)
+        {
+            TacticalPrototypeVisual.CreateBlock(name, position, scale, color, transform, true);
+        }
+
+        private void CreateWall(string name, Vector3 position, Vector3 scale, Color color)
+        {
+            TacticalPrototypeVisual.CreateBlock(name, position, scale, color, transform, true);
+        }
+    }
+}

--- a/Assets/Scripts/TacticalSquad/TacticalPrototypeWorld.cs.meta
+++ b/Assets/Scripts/TacticalSquad/TacticalPrototypeWorld.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f367f92459b64206a0884f55ca4459d7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/TacticalSquad/TacticalSquadDirector.cs
+++ b/Assets/Scripts/TacticalSquad/TacticalSquadDirector.cs
@@ -1,0 +1,781 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Sipoga.Tactics
+{
+    public enum TacticalPrototypePhase
+    {
+        Planning,
+        Execution,
+        AfterAction
+    }
+
+    public sealed class TacticalEventRecord
+    {
+        public float Time;
+        public string Text;
+
+        public TacticalEventRecord(float time, string text)
+        {
+            Time = time;
+            Text = text;
+        }
+    }
+
+    public sealed class TacticalSquadDirector : MonoBehaviour
+    {
+        private readonly Dictionary<string, TacticalUnitAgent> _agents =
+            new Dictionary<string, TacticalUnitAgent>();
+        private readonly List<TacticalEventRecord> _events =
+            new List<TacticalEventRecord>();
+        private readonly Dictionary<string, string> _lastRouteStatus =
+            new Dictionary<string, string>();
+
+        private TacticalScenarioDefinition _scenario;
+        private TacticalPrototypeWorld _world;
+        private TacticalPrototypeCamera _cameraController;
+        private TacticalStateEngine _engine;
+        private TacticalEvaluation _evaluation;
+        private TacticalMissionScorer _missionScorer;
+        private TacticalPrototypePhase _phase = TacticalPrototypePhase.Planning;
+        private TacticalControlMode _controlMode = TacticalControlMode.Guided;
+        private int _playbookIndex;
+        private int _nextAttackStep;
+        private float _executionTime;
+        private string _selectedUnitId = "alpha";
+        private string _lastFlexDirectiveKey = string.Empty;
+        private bool _initialized;
+
+        public TacticalStateEngine Engine
+        {
+            get { return _engine; }
+        }
+
+        public TacticalEvaluation Evaluation
+        {
+            get { return _evaluation; }
+        }
+
+        public TacticalScenarioDefinition Scenario
+        {
+            get { return _scenario; }
+        }
+
+        public TacticalPrototypePhase Phase
+        {
+            get { return _phase; }
+        }
+
+        public TacticalControlMode ControlMode
+        {
+            get { return _controlMode; }
+        }
+
+        public float ExecutionTime
+        {
+            get { return _executionTime; }
+        }
+
+        public string SelectedUnitId
+        {
+            get { return _selectedUnitId; }
+        }
+
+        public IList<TacticalEventRecord> Events
+        {
+            get { return _events; }
+        }
+
+        public TacticalMissionReport MissionReport
+        {
+            get
+            {
+                return _missionScorer != null
+                    ? _missionScorer.BuildReport(_executionTime)
+                    : null;
+            }
+        }
+
+        public TacticalAttackPlaybook CurrentPlaybook
+        {
+            get
+            {
+                if (_scenario == null || _scenario.AttackPlaybooks.Count == 0)
+                {
+                    return null;
+                }
+
+                return _scenario.AttackPlaybooks[_playbookIndex];
+            }
+        }
+
+        public void Initialize(TacticalScenarioDefinition scenario, TacticalPrototypeWorld world)
+        {
+            _scenario = scenario;
+            _world = world;
+            _engine = new TacticalStateEngine(scenario);
+            _evaluation = _engine.Evaluate();
+            _missionScorer = new TacticalMissionScorer(scenario);
+            _initialized = true;
+            ResetCurrentPlaybook();
+        }
+
+        public void RegisterAgent(TacticalUnitAgent agent)
+        {
+            if (agent == null || string.IsNullOrEmpty(agent.UnitId))
+            {
+                return;
+            }
+
+            _agents[agent.UnitId] = agent;
+            agent.SetSelected(agent.UnitId == _selectedUnitId);
+        }
+
+        public void SetCameraController(TacticalPrototypeCamera cameraController)
+        {
+            _cameraController = cameraController;
+            TacticalUnitAgent selected = GetAgent(_selectedUnitId);
+            if (selected != null)
+            {
+                _cameraController.SetSelectedAgent(selected);
+            }
+        }
+
+        public TacticalUnitAgent GetAgent(string unitId)
+        {
+            TacticalUnitAgent agent;
+            return _agents.TryGetValue(unitId, out agent) ? agent : null;
+        }
+
+        public void SelectUnit(string unitId)
+        {
+            if (!_agents.ContainsKey(unitId))
+            {
+                return;
+            }
+
+            TacticalUnitAgent previous = GetAgent(_selectedUnitId);
+            if (previous != null)
+            {
+                previous.SetSelected(false);
+            }
+
+            _selectedUnitId = unitId;
+            TacticalUnitAgent selected = GetAgent(_selectedUnitId);
+            selected.SetSelected(true);
+            if (_cameraController != null)
+            {
+                _cameraController.SetSelectedAgent(selected);
+            }
+        }
+
+        public void SelectUnitByIndex(int index)
+        {
+            if (_scenario == null || index < 0 || index >= _scenario.Units.Count)
+            {
+                return;
+            }
+
+            SelectUnit(_scenario.Units[index].UnitId);
+        }
+
+        public void ToggleView()
+        {
+            if (_cameraController != null)
+            {
+                _cameraController.ToggleMode();
+            }
+        }
+
+        public void ToggleControlMode()
+        {
+            _controlMode = _controlMode == TacticalControlMode.Guided
+                ? TacticalControlMode.Command
+                : TacticalControlMode.Guided;
+
+            if (_controlMode == TacticalControlMode.Guided)
+            {
+                AddEvent("GUIDED MODE: the reserve automatically follows the highest-pressure broken promise.");
+                Recalculate(true, true);
+            }
+            else
+            {
+                AddEvent("COMMAND MODE: Foxtrot waits for your route order. Use the command bar or press Q.");
+                Recalculate(false, true);
+            }
+        }
+
+        public void StartOrRestartExecution()
+        {
+            if (_phase != TacticalPrototypePhase.Planning)
+            {
+                ResetCurrentPlaybook();
+            }
+
+            _phase = TacticalPrototypePhase.Execution;
+            _executionTime = 0f;
+            _nextAttackStep = 0;
+            _missionScorer.Begin();
+            AddEvent("EXECUTE: " + CurrentPlaybook.Name + ". " + CurrentPlaybook.Summary);
+        }
+
+        public void ResetCurrentPlaybook()
+        {
+            if (!_initialized)
+            {
+                return;
+            }
+
+            _engine.Reset();
+            _missionScorer.Reset();
+            _phase = TacticalPrototypePhase.Planning;
+            _executionTime = 0f;
+            _nextAttackStep = 0;
+            _events.Clear();
+            _lastRouteStatus.Clear();
+            _lastFlexDirectiveKey = "reserve";
+
+            for (int i = 0; i < _scenario.Units.Count; i++)
+            {
+                TacticalUnitPlan plan = _scenario.Units[i];
+                TacticalUnitAgent agent = GetAgent(plan.UnitId);
+                if (agent != null)
+                {
+                    agent.SetDown(false);
+                    agent.Warp(_engine.GetPosition(plan.HomePositionId));
+                }
+            }
+
+            for (int i = 0; i < _scenario.Surfaces.Count; i++)
+            {
+                TacticalSurfaceDefinition surface = _scenario.Surfaces[i];
+                if (_world != null)
+                {
+                    _world.UpdateSurface(surface.Id, surface.DefaultState);
+                }
+            }
+
+            Recalculate(false, false);
+            AddEvent(
+                "PLAN READY: " + CurrentPlaybook.Name +
+                ". Press Space or Begin to run the attack in " +
+                _controlMode.ToString().ToUpperInvariant() + " mode.");
+        }
+
+        public void NextPlaybook()
+        {
+            if (_scenario == null || _scenario.AttackPlaybooks.Count == 0)
+            {
+                return;
+            }
+
+            _playbookIndex = (_playbookIndex + 1) % _scenario.AttackPlaybooks.Count;
+            ResetCurrentPlaybook();
+        }
+
+        public void PreviousPlaybook()
+        {
+            if (_scenario == null || _scenario.AttackPlaybooks.Count == 0)
+            {
+                return;
+            }
+
+            _playbookIndex--;
+            if (_playbookIndex < 0)
+            {
+                _playbookIndex = _scenario.AttackPlaybooks.Count - 1;
+            }
+
+            ResetCurrentPlaybook();
+        }
+
+        public void OrderSelectedFallback()
+        {
+            TacticalUnitPlan plan = _engine.GetUnitPlan(_selectedUnitId);
+            if (plan == null)
+            {
+                return;
+            }
+
+            OrderUnitTo(_selectedUnitId, plan.FallbackPositionId, plan.Callsign + " falls back.");
+        }
+
+        public void OrderSelectedToAssignment()
+        {
+            TacticalUnitPlan plan = _engine.GetUnitPlan(_selectedUnitId);
+            if (plan == null)
+            {
+                return;
+            }
+
+            string targetPositionId = plan.HomePositionId;
+            if (plan.IsFlex && _evaluation.FlexDirective.IsActive)
+            {
+                targetPositionId = _evaluation.FlexDirective.PositionId;
+            }
+
+            OrderUnitTo(
+                _selectedUnitId,
+                targetPositionId,
+                plan.Callsign + " returns to the assigned promise.");
+        }
+
+        public void OrderFlexToRecommended()
+        {
+            TacticalFlexDirective directive = _evaluation != null
+                ? _evaluation.FlexDirective
+                : null;
+            if (directive == null || !directive.IsActive)
+            {
+                TacticalUnitPlan flexPlan = _engine.GetUnitPlan(GlasshouseScenario.FlexUnitId);
+                if (flexPlan != null)
+                {
+                    OrderUnitTo(
+                        GlasshouseScenario.FlexUnitId,
+                        flexPlan.HomePositionId,
+                        "COMMAND: no broken promise. Foxtrot returns to reserve.");
+                }
+                return;
+            }
+
+            OrderFlexToRoute(directive.RouteId);
+        }
+
+        public void OrderFlexToRoute(string routeId)
+        {
+            TacticalFlexOption option = FindFlexOption(routeId);
+            TacticalUnitAgent flexAgent = GetAgent(GlasshouseScenario.FlexUnitId);
+            if (option == null || flexAgent == null || flexAgent.IsDown)
+            {
+                return;
+            }
+
+            if (_phase == TacticalPrototypePhase.Execution)
+            {
+                _missionScorer.RecordCommand(routeId, _evaluation.FlexDirective);
+            }
+
+            TacticalRouteDefinition route = _engine.GetRouteDefinition(routeId);
+            string routeLabel = route != null ? route.Label : routeId;
+            AddEvent("COMMAND: FOXTROT -> " + routeLabel + ".");
+            OrderUnitToInternal(GlasshouseScenario.FlexUnitId, option.PositionId);
+            Recalculate(false, true);
+        }
+
+        public void ToggleSelectedDown()
+        {
+            TacticalUnitRuntimeState state = _engine.GetUnitState(_selectedUnitId);
+            if (state == null)
+            {
+                return;
+            }
+
+            bool down = state.Condition != TacticalUnitCondition.Down;
+            SetUnitDown(_selectedUnitId, down, true);
+        }
+
+        public void CyclePermeableScreen()
+        {
+            TacticalSurfaceState current = _engine.GetSurfaceState(GlasshouseScenario.PermeableScreenId);
+            TacticalSurfaceState next;
+            if (current == TacticalSurfaceState.Permeable)
+            {
+                next = TacticalSurfaceState.Sealed;
+            }
+            else if (current == TacticalSurfaceState.Sealed)
+            {
+                next = TacticalSurfaceState.Open;
+            }
+            else
+            {
+                next = TacticalSurfaceState.Permeable;
+            }
+
+            SetSurfaceState(
+                GlasshouseScenario.PermeableScreenId,
+                next,
+                "Overwatch screen changed to " + next.ToString().ToUpperInvariant() + ".");
+        }
+
+        public void TriggerGoCode()
+        {
+            AddEvent("GO CODE: Collapse toward the objective thresholds.");
+            for (int i = 0; i < _scenario.Units.Count; i++)
+            {
+                TacticalUnitPlan plan = _scenario.Units[i];
+                TacticalUnitRuntimeState state = _engine.GetUnitState(plan.UnitId);
+                if (state != null && state.Condition == TacticalUnitCondition.Active)
+                {
+                    OrderUnitToInternal(plan.UnitId, plan.ExecutePositionId);
+                }
+            }
+
+            Recalculate(false, true);
+        }
+
+        public void NotifyUnitArrived(string unitId, string positionId)
+        {
+            _engine.SetUnitPosition(unitId, positionId);
+            TacticalUnitPlan plan = _engine.GetUnitPlan(unitId);
+            TacticalPositionDefinition position = _engine.GetPosition(positionId);
+            if (plan != null && position != null)
+            {
+                AddEvent(plan.Callsign + " reaches " + position.Label + ".");
+            }
+
+            Recalculate(true, true);
+        }
+
+        public void NotifyUnitLeftPosition(string unitId)
+        {
+            _engine.MarkUnitInTransit(unitId);
+            Recalculate(true, true);
+        }
+
+        public void NotifyManualMovementEnded(TacticalUnitAgent agent)
+        {
+            if (agent == null)
+            {
+                return;
+            }
+
+            TacticalPositionDefinition nearest = _engine.FindNearestPosition(
+                agent.transform.position,
+                agent.CurrentFloor,
+                1.0f);
+            if (nearest != null)
+            {
+                agent.Warp(nearest);
+                _engine.SetUnitPosition(agent.UnitId, nearest.Id);
+                AddEvent(agent.Plan.Callsign + " settles at " + nearest.Label + ".");
+            }
+
+            Recalculate(true, true);
+        }
+
+        private void Update()
+        {
+            if (!_initialized)
+            {
+                return;
+            }
+
+            HandleKeyboardInput();
+
+            if (_phase == TacticalPrototypePhase.Execution)
+            {
+                _executionTime += Time.deltaTime;
+                TacticalAttackPlaybook playbook = CurrentPlaybook;
+                while (_nextAttackStep < playbook.Steps.Count &&
+                       playbook.Steps[_nextAttackStep].Time <= _executionTime)
+                {
+                    ApplyAttackStep(playbook.Steps[_nextAttackStep]);
+                    _nextAttackStep++;
+                }
+
+                _missionScorer.Tick(Time.deltaTime, _executionTime, _evaluation);
+
+                if (_executionTime >= playbook.Duration)
+                {
+                    _missionScorer.Finish(_evaluation);
+                    _phase = TacticalPrototypePhase.AfterAction;
+                    TacticalMissionReport report = MissionReport;
+                    AddEvent(
+                        "RESULT " + report.Grade + ": " +
+                        report.ControlPercent.ToString("0") + "% map control preserved.");
+                    AddEvent("AFTER ACTION: " + playbook.Lesson);
+                }
+            }
+        }
+
+        private void HandleKeyboardInput()
+        {
+            if (Input.GetKeyDown(KeyCode.Alpha1)) SelectUnitByIndex(0);
+            if (Input.GetKeyDown(KeyCode.Alpha2)) SelectUnitByIndex(1);
+            if (Input.GetKeyDown(KeyCode.Alpha3)) SelectUnitByIndex(2);
+            if (Input.GetKeyDown(KeyCode.Alpha4)) SelectUnitByIndex(3);
+            if (Input.GetKeyDown(KeyCode.Alpha5)) SelectUnitByIndex(4);
+            if (Input.GetKeyDown(KeyCode.Alpha6)) SelectUnitByIndex(5);
+
+            if (Input.GetKeyDown(KeyCode.Tab)) ToggleView();
+            if (Input.GetKeyDown(KeyCode.Space)) StartOrRestartExecution();
+            if (Input.GetKeyDown(KeyCode.R)) ResetCurrentPlaybook();
+            if (Input.GetKeyDown(KeyCode.P)) NextPlaybook();
+            if (Input.GetKeyDown(KeyCode.LeftBracket)) PreviousPlaybook();
+            if (Input.GetKeyDown(KeyCode.RightBracket)) NextPlaybook();
+            if (Input.GetKeyDown(KeyCode.F)) OrderSelectedFallback();
+            if (Input.GetKeyDown(KeyCode.H)) OrderSelectedToAssignment();
+            if (Input.GetKeyDown(KeyCode.X)) ToggleSelectedDown();
+            if (Input.GetKeyDown(KeyCode.B)) CyclePermeableScreen();
+            if (Input.GetKeyDown(KeyCode.G)) TriggerGoCode();
+            if (Input.GetKeyDown(KeyCode.M)) ToggleControlMode();
+            if (Input.GetKeyDown(KeyCode.Q)) OrderFlexToRecommended();
+
+            if (_cameraController == null || _cameraController.IsTacticalView)
+            {
+                return;
+            }
+
+            float horizontal = 0f;
+            float vertical = 0f;
+            if (Input.GetKey(KeyCode.A)) horizontal -= 1f;
+            if (Input.GetKey(KeyCode.D)) horizontal += 1f;
+            if (Input.GetKey(KeyCode.S)) vertical -= 1f;
+            if (Input.GetKey(KeyCode.W)) vertical += 1f;
+
+            Vector2 input = Vector2.ClampMagnitude(new Vector2(horizontal, vertical), 1f);
+            if (input.sqrMagnitude > 0.001f)
+            {
+                TacticalUnitAgent selected = GetAgent(_selectedUnitId);
+                if (selected != null)
+                {
+                    Vector3 direction =
+                        _cameraController.PlanarRight * input.x +
+                        _cameraController.PlanarForward * input.y;
+                    selected.ManualMove(direction, 4.3f);
+                }
+            }
+        }
+
+        private void ApplyAttackStep(TacticalAttackStep step)
+        {
+            switch (step.Action)
+            {
+                case TacticalAttackAction.SetPressure:
+                    _engine.SetRoutePressure(step.TargetId, step.IntValue);
+                    AddEvent(step.Message);
+                    Recalculate(true, true);
+                    break;
+
+                case TacticalAttackAction.SetSurfaceState:
+                    SetSurfaceState(step.TargetId, step.SurfaceState, step.Message);
+                    break;
+
+                case TacticalAttackAction.SetUnitDown:
+                    if (!string.IsNullOrEmpty(step.Message))
+                    {
+                        AddEvent(step.Message);
+                    }
+                    SetUnitDown(step.TargetId, step.BoolValue, false);
+                    break;
+
+                default:
+                    AddEvent(step.Message);
+                    break;
+            }
+        }
+
+        private void SetUnitDown(string unitId, bool down, bool addDefaultLog)
+        {
+            _engine.SetUnitDown(unitId, down);
+            TacticalUnitAgent agent = GetAgent(unitId);
+            if (agent != null)
+            {
+                agent.SetDown(down);
+            }
+
+            if (addDefaultLog)
+            {
+                TacticalUnitPlan plan = _engine.GetUnitPlan(unitId);
+                AddEvent(plan.Callsign + (down ? " goes down." : " is restored for testing."));
+            }
+
+            Recalculate(true, true);
+        }
+
+        private void SetSurfaceState(string surfaceId, TacticalSurfaceState state, string message)
+        {
+            _engine.SetSurfaceState(surfaceId, state);
+            if (_world != null)
+            {
+                _world.UpdateSurface(surfaceId, state);
+            }
+
+            if (!string.IsNullOrEmpty(message))
+            {
+                AddEvent(message);
+            }
+
+            Recalculate(true, true);
+        }
+
+        private void OrderUnitTo(string unitId, string positionId, string message)
+        {
+            TacticalUnitRuntimeState state = _engine.GetUnitState(unitId);
+            if (state == null || state.Condition == TacticalUnitCondition.Down)
+            {
+                return;
+            }
+
+            if (!string.IsNullOrEmpty(message))
+            {
+                AddEvent(message);
+            }
+
+            OrderUnitToInternal(unitId, positionId);
+            Recalculate(false, true);
+        }
+
+        private void OrderUnitToInternal(string unitId, string positionId)
+        {
+            TacticalUnitAgent agent = GetAgent(unitId);
+            TacticalPositionDefinition target = _engine.GetPosition(positionId);
+            if (agent == null || target == null)
+            {
+                return;
+            }
+
+            TacticalUnitRuntimeState state = _engine.GetUnitState(unitId);
+            if (state != null && !state.IsInTransit && state.PositionId == positionId)
+            {
+                return;
+            }
+
+            if (agent.IsMoving && agent.TargetPositionId == positionId)
+            {
+                return;
+            }
+
+            _engine.MarkUnitInTransit(unitId);
+            agent.OrderTo(target);
+        }
+
+        private void Recalculate(bool synchronizeFlex, bool logTransitions)
+        {
+            _evaluation = _engine.Evaluate();
+            if (synchronizeFlex)
+            {
+                SynchronizeFlexOrder(logTransitions);
+                _evaluation = _engine.Evaluate();
+            }
+
+            if (logTransitions)
+            {
+                LogRouteTransitions();
+            }
+            else
+            {
+                SnapshotRouteStatuses();
+            }
+        }
+
+        private void SynchronizeFlexOrder(bool logTransitions)
+        {
+            TacticalUnitPlan flexPlan = _engine.GetUnitPlan(GlasshouseScenario.FlexUnitId);
+            TacticalUnitAgent flexAgent = GetAgent(GlasshouseScenario.FlexUnitId);
+            if (flexPlan == null || flexAgent == null || flexAgent.IsDown)
+            {
+                return;
+            }
+
+            TacticalFlexDirective directive = _evaluation.FlexDirective;
+            string directiveKey = directive.IsActive ? directive.RouteId : "reserve";
+            if (directiveKey != _lastFlexDirectiveKey)
+            {
+                if (logTransitions)
+                {
+                    if (directive.IsActive)
+                    {
+                        TacticalRouteDefinition route = _engine.GetRouteDefinition(directive.RouteId);
+                        string prefix = _controlMode == TacticalControlMode.Guided
+                            ? "FOXTROT REASSIGNED: repair "
+                            : "RESERVE RECOMMENDATION: send Foxtrot to ";
+                        AddEvent(prefix + route.Label + ".");
+                    }
+                    else
+                    {
+                        string message = _controlMode == TacticalControlMode.Guided
+                            ? "FOXTROT RELEASED: all baseline promises are intact."
+                            : "RESERVE CLEAR: all baseline promises are intact.";
+                        AddEvent(message);
+                    }
+                }
+
+                _lastFlexDirectiveKey = directiveKey;
+            }
+
+            if (_controlMode == TacticalControlMode.Command)
+            {
+                return;
+            }
+
+            bool playerIsManuallyDrivingFlex =
+                _selectedUnitId == GlasshouseScenario.FlexUnitId &&
+                _cameraController != null &&
+                !_cameraController.IsTacticalView &&
+                flexAgent.IsManual;
+            if (playerIsManuallyDrivingFlex)
+            {
+                return;
+            }
+
+            string targetPositionId = directive.IsActive
+                ? directive.PositionId
+                : flexPlan.HomePositionId;
+            OrderUnitToInternal(GlasshouseScenario.FlexUnitId, targetPositionId);
+        }
+
+        private void LogRouteTransitions()
+        {
+            for (int i = 0; i < _evaluation.Routes.Count; i++)
+            {
+                TacticalRouteRuntimeState routeState = _evaluation.Routes[i];
+                string current = routeState.StatusLabel + "-" + routeState.Coverage;
+                string previous;
+                if (_lastRouteStatus.TryGetValue(routeState.RouteId, out previous) && previous != current)
+                {
+                    TacticalRouteDefinition route = _engine.GetRouteDefinition(routeState.RouteId);
+                    AddEvent(
+                        route.Label + " is " + routeState.StatusLabel +
+                        " (" + routeState.Coverage + "/" + routeState.RequiredCoverage + " promises).");
+                }
+
+                _lastRouteStatus[routeState.RouteId] = current;
+            }
+        }
+
+        private void SnapshotRouteStatuses()
+        {
+            _lastRouteStatus.Clear();
+            for (int i = 0; i < _evaluation.Routes.Count; i++)
+            {
+                TacticalRouteRuntimeState routeState = _evaluation.Routes[i];
+                _lastRouteStatus[routeState.RouteId] =
+                    routeState.StatusLabel + "-" + routeState.Coverage;
+            }
+        }
+
+        private TacticalFlexOption FindFlexOption(string routeId)
+        {
+            if (_scenario == null)
+            {
+                return null;
+            }
+
+            for (int i = 0; i < _scenario.FlexOptions.Count; i++)
+            {
+                if (_scenario.FlexOptions[i].RouteId == routeId)
+                {
+                    return _scenario.FlexOptions[i];
+                }
+            }
+
+            return null;
+        }
+
+        private void AddEvent(string text)
+        {
+            if (string.IsNullOrEmpty(text))
+            {
+                return;
+            }
+
+            _events.Add(new TacticalEventRecord(_executionTime, text));
+            const int maxEvents = 12;
+            while (_events.Count > maxEvents)
+            {
+                _events.RemoveAt(0);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/TacticalSquad/TacticalSquadDirector.cs.meta
+++ b/Assets/Scripts/TacticalSquad/TacticalSquadDirector.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4c4ba9d687b6485a9e94bcc87b0938ef
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/TacticalSquad/TacticalThreatVisualizer.cs
+++ b/Assets/Scripts/TacticalSquad/TacticalThreatVisualizer.cs
@@ -1,0 +1,188 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Sipoga.Tactics
+{
+    /// <summary>
+    /// Turns abstract route pressure into visible attacking bodies. The tokens do
+    /// not make tactical decisions; they expose the attacker's current weight and
+    /// whether a defended route is holding, being repaired, or collapsing.
+    /// </summary>
+    public sealed class TacticalThreatVisualizer : MonoBehaviour
+    {
+        private sealed class ThreatLane
+        {
+            public TacticalRouteDefinition Route;
+            public readonly List<GameObject> Tokens = new List<GameObject>();
+            public float Progress;
+        }
+
+        private readonly Dictionary<string, ThreatLane> _lanes =
+            new Dictionary<string, ThreatLane>();
+        private TacticalSquadDirector _director;
+        private Material _holdingMaterial;
+        private Material _advancingMaterial;
+        private Material _repairedMaterial;
+
+        public void Initialize(TacticalSquadDirector director)
+        {
+            _director = director;
+            _holdingMaterial = TacticalPrototypeVisual.GetMaterial(
+                new Color(0.72f, 0.20f, 0.24f),
+                true);
+            _advancingMaterial = TacticalPrototypeVisual.GetMaterial(
+                new Color(1.00f, 0.16f, 0.22f),
+                true);
+            _repairedMaterial = TacticalPrototypeVisual.GetMaterial(
+                new Color(1.00f, 0.53f, 0.16f),
+                true);
+            BuildLanes();
+        }
+
+        private void BuildLanes()
+        {
+            Transform root = new GameObject("Attacker pressure tokens").transform;
+            root.SetParent(transform, false);
+
+            for (int routeIndex = 0; routeIndex < _director.Scenario.Routes.Count; routeIndex++)
+            {
+                TacticalRouteDefinition route = _director.Scenario.Routes[routeIndex];
+                ThreatLane lane = new ThreatLane();
+                lane.Route = route;
+                lane.Progress = 0f;
+
+                for (int tokenIndex = 0; tokenIndex < 8; tokenIndex++)
+                {
+                    GameObject token = GameObject.CreatePrimitive(PrimitiveType.Capsule);
+                    token.name = "Attacker " + route.Label + " " + (tokenIndex + 1);
+                    token.transform.SetParent(root, false);
+                    token.transform.localScale = new Vector3(0.25f, 0.34f, 0.25f);
+                    Collider collider = token.GetComponent<Collider>();
+                    if (collider != null)
+                    {
+                        Destroy(collider);
+                    }
+
+                    Renderer renderer = token.GetComponent<Renderer>();
+                    renderer.sharedMaterial = _holdingMaterial;
+                    token.SetActive(false);
+                    lane.Tokens.Add(token);
+                }
+
+                _lanes.Add(route.Id, lane);
+            }
+        }
+
+        private void Update()
+        {
+            if (_director == null || _director.Evaluation == null)
+            {
+                return;
+            }
+
+            if (_director.Phase == TacticalPrototypePhase.Planning)
+            {
+                ResetLanes();
+                return;
+            }
+
+            float deltaTime = Time.deltaTime;
+            foreach (KeyValuePair<string, ThreatLane> pair in _lanes)
+            {
+                TacticalRouteRuntimeState routeState = _director.Evaluation.GetRoute(pair.Key);
+                UpdateLane(pair.Value, routeState, deltaTime);
+            }
+        }
+
+        private void UpdateLane(
+            ThreatLane lane,
+            TacticalRouteRuntimeState routeState,
+            float deltaTime)
+        {
+            if (routeState == null)
+            {
+                SetTokenCount(lane, 0);
+                return;
+            }
+
+            int visibleCount = Mathf.Clamp(routeState.Pressure, 0, lane.Tokens.Count);
+            SetTokenCount(lane, visibleCount);
+            if (visibleCount <= 0)
+            {
+                lane.Progress = Mathf.MoveTowards(lane.Progress, 0f, deltaTime * 0.8f);
+                return;
+            }
+
+            float heldLimit = Mathf.Clamp(0.18f + routeState.Pressure * 0.025f, 0.22f, 0.45f);
+            float targetProgress;
+            float speed;
+            if (!routeState.IsSecured && !routeState.IsBeingRepaired)
+            {
+                targetProgress = 0.96f;
+                speed = 0.055f + routeState.Pressure * 0.014f;
+            }
+            else if (routeState.IsBeingRepaired)
+            {
+                targetProgress = 0.68f;
+                speed = 0.045f + routeState.Pressure * 0.010f;
+            }
+            else
+            {
+                targetProgress = heldLimit;
+                speed = routeState.IsFlexHolding ? 0.22f : 0.14f;
+            }
+
+            lane.Progress = Mathf.MoveTowards(lane.Progress, targetProgress, speed * deltaTime);
+            Vector3 direction = lane.Route.End - lane.Route.Start;
+            Vector3 flatDirection = new Vector3(direction.x, 0f, direction.z).normalized;
+            Quaternion rotation = flatDirection.sqrMagnitude > 0.001f
+                ? Quaternion.LookRotation(flatDirection, Vector3.up)
+                : Quaternion.identity;
+            Material material = routeState.IsFlexHolding
+                ? _repairedMaterial
+                : routeState.IsSecured
+                    ? _holdingMaterial
+                    : _advancingMaterial;
+
+            for (int i = 0; i < visibleCount; i++)
+            {
+                GameObject token = lane.Tokens[i];
+                float spacing = 0.065f;
+                float tokenProgress = Mathf.Clamp01(lane.Progress - i * spacing);
+                float side = ((i % 3) - 1) * 0.26f;
+                Vector3 lateral = Vector3.Cross(Vector3.up, flatDirection) * side;
+                Vector3 position = Vector3.Lerp(
+                    lane.Route.Start,
+                    lane.Route.End,
+                    tokenProgress);
+                position += lateral + Vector3.up * 0.48f;
+                token.transform.position = position;
+                token.transform.rotation = rotation;
+                Renderer renderer = token.GetComponent<Renderer>();
+                renderer.sharedMaterial = material;
+
+                float pulse = 1f + Mathf.Sin(
+                    Time.time * 7f + i * 1.3f) *
+                    (!routeState.IsSecured ? 0.10f : 0.035f);
+                token.transform.localScale = new Vector3(0.25f, 0.34f, 0.25f) * pulse;
+            }
+        }
+
+        private static void SetTokenCount(ThreatLane lane, int visibleCount)
+        {
+            for (int i = 0; i < lane.Tokens.Count; i++)
+            {
+                lane.Tokens[i].SetActive(i < visibleCount);
+            }
+        }
+
+        private void ResetLanes()
+        {
+            foreach (KeyValuePair<string, ThreatLane> pair in _lanes)
+            {
+                pair.Value.Progress = 0f;
+                SetTokenCount(pair.Value, 0);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/TacticalSquad/TacticalThreatVisualizer.cs.meta
+++ b/Assets/Scripts/TacticalSquad/TacticalThreatVisualizer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 34ba26f6a68b4546bafbb5a8c31a0e67
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/TacticalSquad/TacticalUnitAgent.cs
+++ b/Assets/Scripts/TacticalSquad/TacticalUnitAgent.cs
@@ -1,0 +1,338 @@
+using UnityEngine;
+
+namespace Sipoga.Tactics
+{
+    public sealed class TacticalUnitAgent : MonoBehaviour
+    {
+        private TacticalSquadDirector _director;
+        private TacticalUnitPlan _plan;
+        private Renderer _bodyRenderer;
+        private Renderer _headRenderer;
+        private Renderer _directionRenderer;
+        private Renderer _selectionRenderer;
+        private TextMesh _label;
+        private Transform _characterVisualRoot;
+        private Color _displayColor;
+        private Vector3 _targetWorldPosition;
+        private string _targetPositionId = string.Empty;
+        private bool _isMoving;
+        private bool _isManual;
+        private bool _isDown;
+        private bool _isSelected;
+        private float _lastManualInputTime;
+        private int _currentFloor;
+
+        [SerializeField]
+        private float moveSpeed = 4.7f;
+
+        public string UnitId
+        {
+            get { return _plan != null ? _plan.UnitId : string.Empty; }
+        }
+
+        public TacticalUnitPlan Plan
+        {
+            get { return _plan; }
+        }
+
+        public string TargetPositionId
+        {
+            get { return _targetPositionId; }
+        }
+
+        public bool IsMoving
+        {
+            get { return _isMoving; }
+        }
+
+        public bool IsManual
+        {
+            get { return _isManual; }
+        }
+
+        public bool IsDown
+        {
+            get { return _isDown; }
+        }
+
+        public int CurrentFloor
+        {
+            get { return _currentFloor; }
+        }
+
+        public void Initialize(
+            TacticalSquadDirector director,
+            TacticalUnitPlan plan,
+            TacticalPositionDefinition initialPosition)
+        {
+            _director = director;
+            _plan = plan;
+            _displayColor = plan.DisplayColor;
+            gameObject.name = plan.Callsign + " Tactical Operator";
+            BuildVisuals();
+            Warp(initialPosition);
+            UpdateVisualState();
+        }
+
+        public void Warp(TacticalPositionDefinition position)
+        {
+            if (position == null)
+            {
+                return;
+            }
+
+            transform.position = position.WorldPosition;
+            _currentFloor = position.Floor;
+            _targetWorldPosition = position.WorldPosition;
+            _targetPositionId = position.Id;
+            _isMoving = false;
+            _isManual = false;
+        }
+
+        public void OrderTo(TacticalPositionDefinition position)
+        {
+            if (position == null || _isDown)
+            {
+                return;
+            }
+
+            _targetWorldPosition = position.WorldPosition;
+            _targetPositionId = position.Id;
+            _currentFloor = position.Floor;
+            _isMoving = Vector3.Distance(transform.position, _targetWorldPosition) > 0.08f;
+            _isManual = false;
+
+            if (!_isMoving)
+            {
+                transform.position = _targetWorldPosition;
+                _director.NotifyUnitArrived(UnitId, _targetPositionId);
+            }
+        }
+
+        public void ManualMove(Vector3 worldDirection, float speed)
+        {
+            if (_isDown || worldDirection.sqrMagnitude < 0.001f)
+            {
+                return;
+            }
+
+            if (!_isManual)
+            {
+                _isManual = true;
+                _isMoving = false;
+                _targetPositionId = string.Empty;
+                _director.NotifyUnitLeftPosition(UnitId);
+            }
+
+            _lastManualInputTime = Time.unscaledTime;
+            Vector3 flatDirection = new Vector3(worldDirection.x, 0f, worldDirection.z).normalized;
+            Vector3 next = transform.position + flatDirection * speed * Time.unscaledDeltaTime;
+            next.x = Mathf.Clamp(next.x, -10.0f, 10.0f);
+            next.z = Mathf.Clamp(next.z, -6.0f, 7.6f);
+            next.y = transform.position.y;
+            transform.position = next;
+
+            if (flatDirection.sqrMagnitude > 0.001f)
+            {
+                transform.rotation = Quaternion.Slerp(
+                    transform.rotation,
+                    Quaternion.LookRotation(flatDirection, Vector3.up),
+                    14f * Time.unscaledDeltaTime);
+            }
+        }
+
+        public void SetDown(bool down)
+        {
+            _isDown = down;
+            if (down)
+            {
+                _isMoving = false;
+                _isManual = false;
+            }
+
+            UpdateVisualState();
+        }
+
+        public void SetSelected(bool selected)
+        {
+            _isSelected = selected;
+            UpdateVisualState();
+        }
+
+        public string GetStatusLabel()
+        {
+            if (_isDown)
+            {
+                return "DOWN";
+            }
+
+            if (_isMoving || _isManual)
+            {
+                return "MOVING";
+            }
+
+            return "HOLDING";
+        }
+
+        private void Update()
+        {
+            if (_isDown)
+            {
+                UpdateLabelTransform();
+                return;
+            }
+
+            if (_isMoving)
+            {
+                Vector3 remaining = _targetWorldPosition - transform.position;
+                float distance = remaining.magnitude;
+                if (distance <= 0.06f)
+                {
+                    transform.position = _targetWorldPosition;
+                    _isMoving = false;
+                    _director.NotifyUnitArrived(UnitId, _targetPositionId);
+                }
+                else
+                {
+                    Vector3 direction = remaining / distance;
+                    float step = Mathf.Min(moveSpeed * Time.deltaTime, distance);
+                    transform.position += direction * step;
+                    Vector3 flat = new Vector3(direction.x, 0f, direction.z);
+                    if (flat.sqrMagnitude > 0.001f)
+                    {
+                        transform.rotation = Quaternion.Slerp(
+                            transform.rotation,
+                            Quaternion.LookRotation(flat.normalized, Vector3.up),
+                            10f * Time.deltaTime);
+                    }
+                }
+            }
+
+            if (_isManual && Time.unscaledTime - _lastManualInputTime > 0.18f)
+            {
+                _isManual = false;
+                _director.NotifyManualMovementEnded(this);
+            }
+
+            UpdateLabelTransform();
+        }
+
+        private void BuildVisuals()
+        {
+            GameObject visualRootObject = new GameObject("Character Visual");
+            visualRootObject.transform.SetParent(transform, false);
+            _characterVisualRoot = visualRootObject.transform;
+
+            GameObject body = GameObject.CreatePrimitive(PrimitiveType.Capsule);
+            body.name = "Body";
+            body.transform.SetParent(_characterVisualRoot, false);
+            body.transform.localPosition = new Vector3(0f, 0f, 0f);
+            body.transform.localScale = new Vector3(0.48f, 0.62f, 0.48f);
+            Collider bodyCollider = body.GetComponent<Collider>();
+            if (bodyCollider != null)
+            {
+                Destroy(bodyCollider);
+            }
+
+            _bodyRenderer = body.GetComponent<Renderer>();
+
+            GameObject head = GameObject.CreatePrimitive(PrimitiveType.Sphere);
+            head.name = "Head";
+            head.transform.SetParent(_characterVisualRoot, false);
+            head.transform.localPosition = new Vector3(0f, 0.92f, 0f);
+            head.transform.localScale = Vector3.one * 0.34f;
+            Collider headCollider = head.GetComponent<Collider>();
+            if (headCollider != null)
+            {
+                Destroy(headCollider);
+            }
+
+            _headRenderer = head.GetComponent<Renderer>();
+
+            GameObject direction = TacticalPrototypeVisual.CreateBlock(
+                "Facing marker",
+                transform.position,
+                new Vector3(0.10f, 0.10f, 0.65f),
+                _displayColor,
+                _characterVisualRoot,
+                false);
+            direction.transform.localPosition = new Vector3(0f, 0.22f, 0.55f);
+            direction.transform.localRotation = Quaternion.identity;
+            _directionRenderer = direction.GetComponent<Renderer>();
+
+            GameObject selection = TacticalPrototypeVisual.CreateCylinder(
+                "Selection ring",
+                transform.position,
+                new Vector3(0.68f, 0.025f, 0.68f),
+                Color.white,
+                transform,
+                false);
+            selection.transform.localPosition = new Vector3(0f, -0.92f, 0f);
+            _selectionRenderer = selection.GetComponent<Renderer>();
+
+            _label = TacticalPrototypeVisual.CreateWorldLabel(
+                _plan.Callsign,
+                transform.position + Vector3.up * 1.55f,
+                0.055f,
+                Color.white,
+                transform);
+            _label.transform.localPosition = new Vector3(0f, 1.55f, 0f);
+        }
+
+        private void UpdateVisualState()
+        {
+            if (_bodyRenderer == null)
+            {
+                return;
+            }
+
+            Color activeColor = _isDown
+                ? Color.Lerp(_displayColor, new Color(0.10f, 0.10f, 0.11f), 0.78f)
+                : _displayColor;
+            _bodyRenderer.sharedMaterial = TacticalPrototypeVisual.GetMaterial(activeColor, true);
+            _headRenderer.sharedMaterial = TacticalPrototypeVisual.GetMaterial(activeColor * 0.88f, true);
+            _directionRenderer.sharedMaterial = TacticalPrototypeVisual.GetMaterial(activeColor, true);
+
+            Color ringColor;
+            if (_isDown)
+            {
+                ringColor = new Color(0.75f, 0.10f, 0.12f);
+            }
+            else if (_isSelected)
+            {
+                ringColor = Color.white;
+            }
+            else
+            {
+                ringColor = new Color(_displayColor.r, _displayColor.g, _displayColor.b, 0.55f);
+            }
+
+            _selectionRenderer.sharedMaterial = TacticalPrototypeVisual.GetMaterial(ringColor, true);
+            _selectionRenderer.gameObject.SetActive(_isSelected || _isDown);
+            if (_characterVisualRoot != null)
+            {
+                _characterVisualRoot.localRotation = _isDown
+                    ? Quaternion.Euler(0f, 0f, 78f)
+                    : Quaternion.identity;
+            }
+
+            if (_label != null)
+            {
+                _label.color = _isDown ? new Color(1f, 0.25f, 0.28f) : Color.white;
+                _label.text = _isDown ? _plan.Callsign + "  DOWN" : _plan.Callsign;
+            }
+        }
+
+        private void UpdateLabelTransform()
+        {
+            if (_label == null)
+            {
+                return;
+            }
+
+            // The label is parented to the unit and already follows it. Keep the
+            // vertical offset stable even while the body is rotated into a down pose.
+            _label.transform.position = transform.position + Vector3.up * 1.55f;
+        }
+    }
+}

--- a/Assets/Scripts/TacticalSquad/TacticalUnitAgent.cs.meta
+++ b/Assets/Scripts/TacticalSquad/TacticalUnitAgent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 53687bc5695d47c794e8f5a82e428a3d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests.meta
+++ b/Assets/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 64635024d5fb4ba48dc64c7ed5bb9b27
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/EditMode.meta
+++ b/Assets/Tests/EditMode.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3300cba91824418e8ff983f8e44df303
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/EditMode/Sipoga.Tactics.Editor.Tests.asmdef
+++ b/Assets/Tests/EditMode/Sipoga.Tactics.Editor.Tests.asmdef
@@ -1,0 +1,18 @@
+{
+  "name": "Sipoga.Tactics.Editor.Tests",
+  "references": [
+    "Sipoga.Tactics"
+  ],
+  "optionalUnityReferences": [
+    "TestAssemblies"
+  ],
+  "includePlatforms": [
+    "Editor"
+  ],
+  "excludePlatforms": [],
+  "allowUnsafeCode": false,
+  "overrideReferences": false,
+  "precompiledReferences": [],
+  "autoReferenced": false,
+  "defineConstraints": []
+}

--- a/Assets/Tests/EditMode/Sipoga.Tactics.Editor.Tests.asmdef.meta
+++ b/Assets/Tests/EditMode/Sipoga.Tactics.Editor.Tests.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 4966f309a65f4170a5df9aa448aac634
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/EditMode/TacticalMissionScorerTests.cs
+++ b/Assets/Tests/EditMode/TacticalMissionScorerTests.cs
@@ -1,0 +1,92 @@
+using NUnit.Framework;
+
+namespace Sipoga.Tactics.Tests
+{
+    public sealed class TacticalMissionScorerTests
+    {
+        private TacticalScenarioDefinition _scenario;
+        private TacticalStateEngine _engine;
+        private TacticalMissionScorer _scorer;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _scenario = GlasshouseScenario.Create();
+            _engine = new TacticalStateEngine(_scenario);
+            _scorer = new TacticalMissionScorer(_scenario);
+        }
+
+        [Test]
+        public void SecuredPressure_PreservesPerfectControl()
+        {
+            _engine.SetRoutePressure(GlasshouseScenario.CrimsonRouteId, 6);
+            TacticalEvaluation evaluation = _engine.Evaluate();
+
+            _scorer.Begin();
+            _scorer.Tick(5f, 5f, evaluation);
+            _scorer.Finish(evaluation);
+            TacticalMissionReport report = _scorer.BuildReport(5f);
+
+            Assert.That(report.ControlPercent, Is.EqualTo(100f).Within(0.01f));
+            Assert.That(report.WeightedExposureSeconds, Is.EqualTo(0f).Within(0.01f));
+            Assert.That(report.Grade, Is.EqualTo("S"));
+        }
+
+        [Test]
+        public void BrokenPromise_AccumulatesExposureUntilPhysicalRepair()
+        {
+            _engine.SetRoutePressure(GlasshouseScenario.CrimsonRouteId, 6);
+            _engine.SetUnitDown("charlie", true);
+            TacticalEvaluation broken = _engine.Evaluate();
+
+            _scorer.Begin();
+            _scorer.Tick(2f, 2f, broken);
+
+            _engine.SetUnitPosition(GlasshouseScenario.FlexUnitId, "flex_crimson");
+            TacticalEvaluation repaired = _engine.Evaluate();
+            _scorer.Tick(1f, 3f, repaired);
+            _scorer.Finish(repaired);
+            TacticalMissionReport report = _scorer.BuildReport(3f);
+
+            Assert.That(report.ControlPercent, Is.EqualTo(77.777f).Within(0.1f));
+            Assert.That(report.RepairCount, Is.EqualTo(1));
+            Assert.That(report.LongestBreakSeconds, Is.EqualTo(2f).Within(0.01f));
+            StringAssert.Contains("CRIMSON STAIR", report.Recommendation);
+        }
+
+        [Test]
+        public void ReserveCommands_RecordWhetherTheRecommendedRouteWasChosen()
+        {
+            _engine.SetUnitDown("charlie", true);
+            _engine.SetRoutePressure(GlasshouseScenario.CrimsonRouteId, 7);
+            TacticalEvaluation evaluation = _engine.Evaluate();
+
+            _scorer.Begin();
+            _scorer.RecordCommand(GlasshouseScenario.ServiceRouteId, evaluation.FlexDirective);
+            _scorer.RecordCommand(GlasshouseScenario.CrimsonRouteId, evaluation.FlexDirective);
+            _scorer.Finish(evaluation);
+            TacticalMissionReport report = _scorer.BuildReport(0f);
+
+            Assert.That(report.CommandCount, Is.EqualTo(2));
+            Assert.That(report.CorrectCommandCount, Is.EqualTo(1));
+            Assert.That(report.CommandAccuracy, Is.EqualTo(0.5f).Within(0.001f));
+        }
+
+        [Test]
+        public void EndingWithPressuredBrokenRoute_ReportsUnansweredThreat()
+        {
+            _engine.SetUnitDown("delta", true);
+            _engine.SetRoutePressure(GlasshouseScenario.CrimsonRouteId, 5);
+            _engine.SetRoutePressure(GlasshouseScenario.ServiceRouteId, 5);
+            TacticalEvaluation evaluation = _engine.Evaluate();
+
+            _scorer.Begin();
+            _scorer.Tick(1f, 1f, evaluation);
+            _scorer.Finish(evaluation);
+            TacticalMissionReport report = _scorer.BuildReport(1f);
+
+            Assert.That(report.UnansweredRoutes, Is.EqualTo(2));
+            Assert.That(report.ControlPercent, Is.LessThan(100f));
+        }
+    }
+}

--- a/Assets/Tests/EditMode/TacticalMissionScorerTests.cs.meta
+++ b/Assets/Tests/EditMode/TacticalMissionScorerTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bbc6d75cefb842bbb80101a37bacba24
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/EditMode/TacticalStateEngineTests.cs
+++ b/Assets/Tests/EditMode/TacticalStateEngineTests.cs
@@ -1,0 +1,139 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+
+namespace Sipoga.Tactics.Tests
+{
+    public sealed class TacticalStateEngineTests
+    {
+        private TacticalScenarioDefinition _scenario;
+        private TacticalStateEngine _engine;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _scenario = GlasshouseScenario.Create();
+            _engine = new TacticalStateEngine(_scenario);
+        }
+
+        [Test]
+        public void GlasshouseScenario_HasNoBrokenReferences()
+        {
+            List<string> errors = TacticalScenarioValidator.Validate(_scenario);
+            Assert.That(errors, Is.Empty, string.Join("\n", errors.ToArray()));
+        }
+
+        [Test]
+        public void InitialPlan_MeetsEveryRequiredPromiseCount()
+        {
+            TacticalEvaluation evaluation = _engine.Evaluate();
+
+            AssertRoute(evaluation, GlasshouseScenario.CrimsonRouteId, 3, 3, true);
+            AssertRoute(evaluation, GlasshouseScenario.ServiceRouteId, 2, 2, true);
+            AssertRoute(evaluation, GlasshouseScenario.ColdHatchRouteId, 1, 1, true);
+            Assert.That(evaluation.FlexDirective.IsActive, Is.False);
+            Assert.That(evaluation.FlexDirective.PositionId, Is.EqualTo("foxtrot_reserve"));
+        }
+
+        [Test]
+        public void GalleryLoss_AssignsFlexAndPhysicalArrivalRepairsCrimson()
+        {
+            _engine.SetRoutePressure(GlasshouseScenario.CrimsonRouteId, 6);
+            _engine.SetUnitDown("charlie", true);
+
+            TacticalEvaluation beforeArrival = _engine.Evaluate();
+            TacticalRouteRuntimeState broken = beforeArrival.GetRoute(GlasshouseScenario.CrimsonRouteId);
+            Assert.That(broken.BaselineCoverage, Is.EqualTo(2));
+            Assert.That(broken.IsSecured, Is.False);
+            Assert.That(broken.IsBeingRepaired, Is.True);
+            Assert.That(beforeArrival.FlexDirective.RouteId, Is.EqualTo(GlasshouseScenario.CrimsonRouteId));
+            Assert.That(beforeArrival.FlexDirective.PositionId, Is.EqualTo("flex_crimson"));
+
+            _engine.SetUnitPosition(GlasshouseScenario.FlexUnitId, "flex_crimson");
+            TacticalEvaluation afterArrival = _engine.Evaluate();
+            TacticalRouteRuntimeState repaired = afterArrival.GetRoute(GlasshouseScenario.CrimsonRouteId);
+            Assert.That(repaired.Coverage, Is.EqualTo(3));
+            Assert.That(repaired.IsSecured, Is.True);
+            Assert.That(repaired.IsFlexHolding, Is.True);
+            Assert.That(repaired.StatusLabel, Is.EqualTo("REPAIRED"));
+        }
+
+        [Test]
+        public void SealingScreen_DeletesRemoteControlWithoutDowningBravo()
+        {
+            _engine.SetRoutePressure(GlasshouseScenario.ColdHatchRouteId, 5);
+            _engine.SetSurfaceState(
+                GlasshouseScenario.PermeableScreenId,
+                TacticalSurfaceState.Sealed);
+
+            TacticalEvaluation evaluation = _engine.Evaluate();
+            TacticalRouteRuntimeState cold = evaluation.GetRoute(GlasshouseScenario.ColdHatchRouteId);
+            Assert.That(_engine.GetUnitState("bravo").Condition, Is.EqualTo(TacticalUnitCondition.Active));
+            Assert.That(cold.BaselineCoverage, Is.EqualTo(0));
+            Assert.That(cold.IsSecured, Is.False);
+            Assert.That(evaluation.FlexDirective.RouteId, Is.EqualTo(GlasshouseScenario.ColdHatchRouteId));
+            Assert.That(evaluation.FlexDirective.PositionId, Is.EqualTo("flex_cold"));
+        }
+
+        [Test]
+        public void OneHingeLoss_CreatesTwoDeficitsAndPressureChoosesTheRepair()
+        {
+            _engine.SetUnitDown("delta", true);
+            _engine.SetRoutePressure(GlasshouseScenario.CrimsonRouteId, 7);
+            _engine.SetRoutePressure(GlasshouseScenario.ServiceRouteId, 4);
+
+            TacticalEvaluation first = _engine.Evaluate();
+            Assert.That(first.GetRoute(GlasshouseScenario.CrimsonRouteId).IsSecured, Is.False);
+            Assert.That(first.GetRoute(GlasshouseScenario.ServiceRouteId).IsSecured, Is.False);
+            Assert.That(first.FlexDirective.RouteId, Is.EqualTo(GlasshouseScenario.CrimsonRouteId));
+
+            _engine.SetRoutePressure(GlasshouseScenario.CrimsonRouteId, 1);
+            _engine.SetRoutePressure(GlasshouseScenario.ServiceRouteId, 8);
+            TacticalEvaluation rotated = _engine.Evaluate();
+            Assert.That(rotated.FlexDirective.RouteId, Is.EqualTo(GlasshouseScenario.ServiceRouteId));
+        }
+
+        [Test]
+        public void LeavingAnAuthoredPosition_RemovesCoverageUntilTheUnitSettlesAgain()
+        {
+            _engine.MarkUnitInTransit("alpha");
+            TacticalEvaluation moving = _engine.Evaluate();
+            TacticalRouteRuntimeState service = moving.GetRoute(GlasshouseScenario.ServiceRouteId);
+
+            Assert.That(service.BaselineCoverage, Is.EqualTo(1));
+            Assert.That(service.IsSecured, Is.False);
+            Assert.That(moving.FlexDirective.RouteId, Is.EqualTo(GlasshouseScenario.ServiceRouteId));
+
+            _engine.SetUnitPosition("alpha", "alpha_archive");
+            TacticalEvaluation restored = _engine.Evaluate();
+            Assert.That(restored.GetRoute(GlasshouseScenario.ServiceRouteId).IsSecured, Is.True);
+            Assert.That(restored.FlexDirective.IsActive, Is.False);
+        }
+
+        [Test]
+        public void OpenScreen_PreservesTheRemoteHatchPromise()
+        {
+            _engine.SetSurfaceState(
+                GlasshouseScenario.PermeableScreenId,
+                TacticalSurfaceState.Open);
+            TacticalEvaluation evaluation = _engine.Evaluate();
+            TacticalRouteRuntimeState cold = evaluation.GetRoute(GlasshouseScenario.ColdHatchRouteId);
+
+            Assert.That(cold.BaselineCoverage, Is.EqualTo(1));
+            Assert.That(cold.IsSecured, Is.True);
+        }
+
+        private static void AssertRoute(
+            TacticalEvaluation evaluation,
+            string routeId,
+            int baseline,
+            int coverage,
+            bool secured)
+        {
+            TacticalRouteRuntimeState route = evaluation.GetRoute(routeId);
+            Assert.That(route, Is.Not.Null);
+            Assert.That(route.BaselineCoverage, Is.EqualTo(baseline));
+            Assert.That(route.Coverage, Is.EqualTo(coverage));
+            Assert.That(route.IsSecured, Is.EqualTo(secured));
+        }
+    }
+}

--- a/Assets/Tests/EditMode/TacticalStateEngineTests.cs.meta
+++ b/Assets/Tests/EditMode/TacticalStateEngineTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ffc693f43e414409be7a3bb287904917
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -4,5 +4,8 @@
 EditorBuildSettings:
   m_ObjectHideFlags: 0
   serializedVersion: 2
-  m_Scenes: []
+  m_Scenes:
+  - enabled: 1
+    path: Assets/Scenes/TacticalSquadPrototype.unity
+    guid: 30d36ee0d7234e81a6365d7640aa5e8f
   m_configObjects: {}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,71 @@
-# sipoga
+# Sipoga
+
+Sipoga is an FPS and squad-control prototype. The current tactical vertical slice asks the player to control six **responsibilities** rather than six independent crosshairs: one operator is directly selected while five deterministic agents maintain a network of routes, crossfires, vertical control, fallbacks, and repairs.
+
+## Tactical squad prototype
+
+Open `Assets/Scenes/TacticalSquadPrototype.unity` in Unity **2020.1.10f1** and press Play, or use:
+
+`Sipoga > Tactical Prototype > Run Glasshouse`
+
+The scene builds itself at runtime from primitives and authored tactical data. It uses no Rainbow Six maps, names, meshes, textures, audio, or other proprietary assets. `Glasshouse` is an original two-floor training map designed around general tactical motifs:
+
+- Three operators form a layered crossfire on Crimson Stair.
+- A hinge operator supports two routes at once.
+- An upper operator remotely denies a hatch through a stateful permeable screen.
+- A sixth reserve operator repairs the highest-pressure broken responsibility.
+- Three attacker playbooks demonstrate isolation, geometry denial, and a simultaneous split.
+- Visible attacker tokens move through each route according to pressure and the current control state.
+
+The same scenario has two control modes:
+
+- **Guided** demonstrates the dependency graph by automatically routing Foxtrot, the reserve operator, to the recommended repair.
+- **Command** leaves Foxtrot in the player's hands. The player must read the threatened routes and issue the repair order before pressure converts into exposure.
+
+A pressure-weighted scorer measures how much threatened map control stayed intact, how long the worst break remained open, whether reserve commands targeted the recommended route, and which route created the most exposure. Every play ends with a letter grade and a concrete coaching note.
+
+### Controls
+
+| Input | Action |
+|---|---|
+| `1`–`6` | Select an operator |
+| `Tab` | Switch between tactical and operator views |
+| `WASD` | Move the selected operator in operator view |
+| `Space` | Begin or restart the current attacker playbook |
+| `P`, `[` or `]` | Change attacker playbook |
+| `M` | Toggle Guided / Command mode |
+| `Q` | Send Foxtrot to the currently recommended repair |
+| Command bar buttons | Send Foxtrot to Crimson, Service, or Cold directly |
+| `F` | Order the selected operator to fallback |
+| `H` | Return the selected operator to their assigned responsibility |
+| `X` | Toggle the selected operator down/restored for testing |
+| `B` | Cycle the Overwatch screen: permeable, sealed, open |
+| `G` | Trigger the squad collapse go-code |
+| `R` | Reset the current playbook |
+
+The HUD answers four questions for every operator: what they are doing, why the position is safe, what breaks it, and where they fall back. Route bands and promise lines update as operators move, go down, or lose a required surface state. The causal event log explains which dependency changed rather than reporting only the visible kill or breach. The command layer turns those explanations into a playable reaction loop rather than a passive diagram.
+
+## Architecture
+
+The prototype is data-driven and self-contained under `Assets/Scripts/TacticalSquad`:
+
+- `GlasshouseScenario` authors positions, routes, surfaces, six unit plans, coverage rules, flex repair options, and attacker timelines.
+- `TacticalStateEngine` is a pure evaluator shared by gameplay, overlays, explanations, tests, and scoring.
+- `TacticalSquadDirector` executes attacker playbooks and supports both automatic and player-commanded reserve behavior.
+- `TacticalMissionScorer` turns pressure, missing promises, repair time, and command accuracy into an after-action report.
+- `TacticalOverlayRenderer` visualizes live promises, broken routes, and reserve assignments.
+- `TacticalThreatVisualizer` converts abstract pressure values into attacker tokens advancing through the map.
+- `TacticalPrototypeHud` explains the plan; `TacticalCommandHud` supplies the command trial and graded debrief.
+- `TacticalPrototypeBootstrap` generates the original map, squad, camera, overlays, and HUD at runtime.
+
+Edit-mode tests live under `Assets/Tests/EditMode`. They verify initial coverage, position-dependent responsibility loss, stateful surface control, flex repairs, pressure-based prioritization, reference integrity, pressure-weighted scoring, break duration, unanswered threats, and command accuracy.
+
+## Validation
+
+Run the repository-level structural checks with:
+
+```sh
+python3 tools/validate_tactical_prototype.py
+```
+
+The validator checks required files, Unity metadata pairs and GUID uniqueness, assembly-definition JSON, C# delimiter balance, prototype wiring, scene registration, and documentation. GitHub Actions runs the same check on pushes and pull requests. This fast validator does not replace importing the project and running its edit-mode tests in Unity.

--- a/tools/validate_tactical_prototype.py
+++ b/tools/validate_tactical_prototype.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+"""Fast structural checks for the self-contained tactical prototype.
+
+This does not replace importing the project in Unity. It catches the common errors
+that can be verified without a Unity installation: malformed assembly definitions,
+missing metadata, duplicate GUIDs, unbalanced C# delimiters, and incomplete scene
+or documentation wiring.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Iterable
+
+ROOT = Path(__file__).resolve().parents[1]
+TACTICS = ROOT / "Assets" / "Scripts" / "TacticalSquad"
+TESTS = ROOT / "Assets" / "Tests" / "EditMode"
+SCENE = ROOT / "Assets" / "Scenes" / "TacticalSquadPrototype.unity"
+
+REQUIRED_FILES = [
+    TACTICS / "GlasshouseScenario.cs",
+    TACTICS / "TacticalModel.cs",
+    TACTICS / "TacticalMissionScoring.cs",
+    TACTICS / "TacticalSquadDirector.cs",
+    TACTICS / "TacticalUnitAgent.cs",
+    TACTICS / "TacticalOverlayRenderer.cs",
+    TACTICS / "TacticalThreatVisualizer.cs",
+    TACTICS / "TacticalPrototypeWorld.cs",
+    TACTICS / "TacticalPrototypeCamera.cs",
+    TACTICS / "TacticalPrototypeHud.cs",
+    TACTICS / "TacticalCommandHud.cs",
+    TACTICS / "TacticalPrototypeBootstrap.cs",
+    TESTS / "TacticalStateEngineTests.cs",
+    TESTS / "TacticalMissionScorerTests.cs",
+    SCENE,
+]
+
+
+def fail(errors: list[str], message: str) -> None:
+    errors.append(message)
+
+
+def strip_csharp_noncode(source: str) -> str:
+    """Replace comments and literals with spaces while preserving newlines."""
+    output: list[str] = []
+    i = 0
+    state = "normal"
+    while i < len(source):
+        ch = source[i]
+        nxt = source[i + 1] if i + 1 < len(source) else ""
+
+        if state == "normal":
+            if ch == "/" and nxt == "/":
+                output.extend("  ")
+                i += 2
+                state = "line_comment"
+                continue
+            if ch == "/" and nxt == "*":
+                output.extend("  ")
+                i += 2
+                state = "block_comment"
+                continue
+            if ch == "@" and nxt == '"':
+                output.extend("  ")
+                i += 2
+                state = "verbatim_string"
+                continue
+            if ch == '"':
+                output.append(" ")
+                i += 1
+                state = "string"
+                continue
+            if ch == "'":
+                output.append(" ")
+                i += 1
+                state = "char"
+                continue
+            output.append(ch)
+            i += 1
+            continue
+
+        if state == "line_comment":
+            if ch == "\n":
+                output.append("\n")
+                state = "normal"
+            else:
+                output.append(" ")
+            i += 1
+            continue
+
+        if state == "block_comment":
+            if ch == "*" and nxt == "/":
+                output.extend("  ")
+                i += 2
+                state = "normal"
+            else:
+                output.append("\n" if ch == "\n" else " ")
+                i += 1
+            continue
+
+        if state == "string":
+            if ch == "\\":
+                output.append(" ")
+                if nxt:
+                    output.append("\n" if nxt == "\n" else " ")
+                    i += 2
+                else:
+                    i += 1
+                continue
+            output.append("\n" if ch == "\n" else " ")
+            i += 1
+            if ch == '"':
+                state = "normal"
+            continue
+
+        if state == "verbatim_string":
+            if ch == '"' and nxt == '"':
+                output.extend("  ")
+                i += 2
+                continue
+            output.append("\n" if ch == "\n" else " ")
+            i += 1
+            if ch == '"':
+                state = "normal"
+            continue
+
+        if state == "char":
+            if ch == "\\":
+                output.append(" ")
+                if nxt:
+                    output.append("\n" if nxt == "\n" else " ")
+                    i += 2
+                else:
+                    i += 1
+                continue
+            output.append("\n" if ch == "\n" else " ")
+            i += 1
+            if ch == "'":
+                state = "normal"
+            continue
+
+    if state in {"block_comment", "string", "verbatim_string", "char"}:
+        raise ValueError(f"unterminated C# token: {state}")
+    return "".join(output)
+
+
+def validate_delimiters(path: Path, errors: list[str]) -> None:
+    source = path.read_text(encoding="utf-8")
+    try:
+        code = strip_csharp_noncode(source)
+    except ValueError as exc:
+        fail(errors, f"{path.relative_to(ROOT)}: {exc}")
+        return
+
+    opening = {"(": ")", "[": "]", "{": "}"}
+    closing = {value: key for key, value in opening.items()}
+    stack: list[tuple[str, int]] = []
+    line = 1
+    for ch in code:
+        if ch == "\n":
+            line += 1
+            continue
+        if ch in opening:
+            stack.append((ch, line))
+        elif ch in closing:
+            if not stack or stack[-1][0] != closing[ch]:
+                fail(errors, f"{path.relative_to(ROOT)}:{line}: unmatched '{ch}'")
+                return
+            stack.pop()
+
+    if stack:
+        symbol, symbol_line = stack[-1]
+        fail(errors, f"{path.relative_to(ROOT)}:{symbol_line}: unclosed '{symbol}'")
+
+
+def tactical_assets() -> Iterable[Path]:
+    for root in (TACTICS, TESTS):
+        if not root.exists():
+            continue
+        for path in root.rglob("*"):
+            if path.is_file() and path.suffix in {".cs", ".asmdef"}:
+                yield path
+    if SCENE.exists():
+        yield SCENE
+
+
+def validate_meta_pairs(errors: list[str]) -> None:
+    for path in tactical_assets():
+        meta = path.with_name(path.name + ".meta")
+        if not meta.exists():
+            fail(errors, f"Missing Unity metadata: {meta.relative_to(ROOT)}")
+
+
+def validate_guids(errors: list[str]) -> None:
+    seen: dict[str, Path] = {}
+    guid_pattern = re.compile(r"^guid:\s*([0-9a-fA-F]{32})\s*$", re.MULTILINE)
+    for meta in (ROOT / "Assets").rglob("*.meta"):
+        text = meta.read_text(encoding="utf-8", errors="replace")
+        match = guid_pattern.search(text)
+        if not match:
+            continue
+        guid = match.group(1).lower()
+        previous = seen.get(guid)
+        if previous is not None:
+            fail(
+                errors,
+                "Duplicate Unity GUID " + guid + ": " +
+                str(previous.relative_to(ROOT)) + " and " + str(meta.relative_to(ROOT)),
+            )
+        else:
+            seen[guid] = meta
+
+
+def validate_json(errors: list[str]) -> None:
+    for asmdef in list(TACTICS.rglob("*.asmdef")) + list(TESTS.rglob("*.asmdef")):
+        try:
+            json.loads(asmdef.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            fail(errors, f"{asmdef.relative_to(ROOT)}: invalid JSON: {exc}")
+
+
+def validate_wiring(errors: list[str]) -> None:
+    for required in REQUIRED_FILES:
+        if not required.exists():
+            fail(errors, f"Missing required prototype file: {required.relative_to(ROOT)}")
+
+    scenario = (TACTICS / "GlasshouseScenario.cs").read_text(encoding="utf-8")
+    if scenario.count("new TacticalUnitPlan(") != 6:
+        fail(errors, "GlasshouseScenario must author exactly six tactical unit plans.")
+    if scenario.count("new TacticalAttackPlaybook(") != 3:
+        fail(errors, "GlasshouseScenario must author exactly three attacker playbooks.")
+
+    bootstrap = (TACTICS / "TacticalPrototypeBootstrap.cs").read_text(encoding="utf-8")
+    for component in (
+        "TacticalOverlayRenderer",
+        "TacticalThreatVisualizer",
+        "TacticalPrototypeHud",
+        "TacticalCommandHud",
+    ):
+        if component not in bootstrap:
+            fail(errors, f"Bootstrap does not wire {component}.")
+
+    build_settings = (ROOT / "ProjectSettings" / "EditorBuildSettings.asset").read_text(
+        encoding="utf-8"
+    )
+    if "Assets/Scenes/TacticalSquadPrototype.unity" not in build_settings:
+        fail(errors, "TacticalSquadPrototype.unity is missing from EditorBuildSettings.asset.")
+
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    for required_text in ("Guided", "Command", "TacticalMissionScorer", "TacticalCommandHud"):
+        if required_text not in readme:
+            fail(errors, f"README is missing the expected documentation term: {required_text}")
+
+
+def main() -> int:
+    errors: list[str] = []
+    validate_meta_pairs(errors)
+    validate_guids(errors)
+    validate_json(errors)
+    validate_wiring(errors)
+
+    for path in list(TACTICS.rglob("*.cs")) + list(TESTS.glob("Tactical*.cs")):
+        validate_delimiters(path, errors)
+
+    if errors:
+        print("Tactical prototype validation failed:")
+        for error in errors:
+            print(f"  - {error}")
+        return 1
+
+    print("Tactical prototype structural checks passed.")
+    print(f"Checked {len(list(TACTICS.rglob('*.cs')))} runtime/editor C# files.")
+    print(f"Checked {len(list(TESTS.glob('Tactical*.cs')))} tactical test files.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Product slice

This PR turns the core Sipoga thesis into a playable Unity vertical slice: the player controls six tactical **responsibilities**, not six simultaneous crosshairs.

The original two-floor map, **Glasshouse**, is generated at runtime and demonstrates the kinds of dependencies that make professional destruction-shooter strategy difficult to see in ordinary first-person footage:

- three independent promises form a layered crossfire on Crimson Stair
- one hinge operator supports two routes at once
- an upper operator remotely denies a hatch through a stateful permeable screen
- a sixth reserve operator, Foxtrot, repairs broken responsibilities
- three coherent attacker playbooks attack the dependency graph through isolation, geometry denial, and a simultaneous split
- attacker pressure appears as visible tokens advancing through the relevant routes

Glasshouse uses no Rainbow Six map geometry, room names, meshes, textures, audio, or other Ubisoft assets.

## Two ways to play

### Guided

The prototype demonstrates the strategy by automatically sending Foxtrot to the highest-pressure broken promise. Route bands, promise lines, movement, and the causal log show why a position remains safe or collapses.

### Command

Foxtrot waits for the player. The player reads the live route state and sends the reserve to Crimson, Service, or Cold before the attack converts a missing promise into exposure. `Q` sends the recommended repair; the command bar also permits deliberate alternate orders.

## Teaching and scoring

For every operator, the HUD answers:

1. What am I doing?
2. Why is this position safe?
3. What breaks it?
4. Where is the fallback?

A pressure-weighted mission scorer measures:

- percentage of threatened map control preserved
- exposure created by missing promises
- longest active route break
- completed repairs
- unanswered routes
- reserve-command accuracy

Every attacker playbook ends with a letter grade, a causal replay, and a concrete coaching recommendation.

## Implementation

- data-authored `GlasshouseScenario`
- pure `TacticalStateEngine` shared by gameplay, overlays, explanations, scoring, and tests
- deterministic `TacticalSquadDirector` with Guided and Command modes
- runtime-generated two-floor environment and six simple operator bodies
- tactical and operator cameras plus manual operator movement
- live route bands, crossfire/promise lines, fallback and repair markers
- visible attacker-pressure visualization
- command HUD and graded after-action report
- state-engine and mission-scoring edit-mode tests
- repository-level structural validator and GitHub Actions workflow

## Run it

Open `Assets/Scenes/TacticalSquadPrototype.unity` in Unity `2020.1.10f1` and press Play, or choose:

`Sipoga > Tactical Prototype > Run Glasshouse`

Useful controls:

- `1–6`: select operator
- `Tab`: tactical/operator view
- `WASD`: move selected operator
- `Space`: begin/restart attack
- `P` or `[ ]`: change attacker playbook
- `M`: Guided/Command mode
- `Q`: send Foxtrot to the recommended repair
- `F` / `H`: fallback / return to responsibility
- `X`: test selected operator down/restored
- `B`: cycle the permeable screen
- `G`: squad collapse go-code
- `R`: reset

## Validation

The automated validator checks required files, Unity metadata pairs and GUID uniqueness, assembly-definition JSON, C# delimiter/string/comment balance, scene/build wiring, six-unit and three-playbook invariants, and documentation. The GitHub Actions check passes on the complete PR tree.

This environment does not have a licensed Unity editor or C# Unity assemblies, so I have **not** claimed that the scene or edit-mode tests were executed inside Unity. A local Unity import/play and Test Runner pass remain the final pre-merge gate.